### PR TITLE
docs: clarify app setup and released portability limits

### DIFF
--- a/.claude/guides/README.md
+++ b/.claude/guides/README.md
@@ -1,5 +1,7 @@
 # Guides
 
+For shared product help, start at [the canonical system guides](../../docs/Dex_System/README.md). This Claude-specific directory is not the user entry point or evidence that another app supports a workflow.
+
 **Purpose:** System documentation and conventions that explain how Dex works and how to use it effectively.
 
 > **Note (2026-07):** this folder is currently an empty tier — the documentation it
@@ -20,7 +22,7 @@ Documentation files that:
 
 Create a guide when:
 - **System-wide pattern** - Convention applies across multiple features
-- **Reference needed** - Users or Claude need to look up standards
+- **Reference needed** - Users or their assistant need to look up standards
 - **Onboarding material** - New users need to understand core concepts
 - **Architecture docs** - Explaining how major components work together
 

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,6 +1,6 @@
 # Claude Code hooks
 
-These hooks provide deterministic lifecycle behavior for Claude Code (**Tier 3 Full**). Cursor, Codex, and other Agent Skills harnesses do not run Claude Code hooks; they stop at **Tier 2 Skills**. Session boot and person context are also **Tier 1 Core** tools (`boot_today`, `get_person_context`) — Cursor/ChatGPT call them; these hooks auto-fire the same functions. The three-bucket inventory (scheduled / in-turn inject / gates) is in [`docs/architecture/HOOK-INVENTORY.md`](../../docs/architecture/HOOK-INVENTORY.md). Do not mass-migrate hooks.
+These are Claude Code-specific lifecycle hooks in the established full-vault setup. Other apps do not run `.claude/settings.json`. Portable adapters share selected context and safety code, but their events, trust and coverage must be proved in each installed app; complete new-app journeys remain unverified despite v1.97.13 package distribution. `boot_today` and `get_person_context` are on-demand tools when registered; they do not supply the whole hook suite. See [surface modes](../../docs/HARNESS-PORTABILITY.md#capability-truth) and [the hook inventory](../../docs/architecture/HOOK-INVENTORY.md). Do not mass-migrate hooks.
 
 The wiring sources of truth are:
 

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,28 +1,32 @@
 # Skills
 
+This is the canonical source catalogue. Generated `.agents/skills/` and packaged copies are built from eligible sources; do not edit those copies independently. A skill supplies instructions, not missing tools or runtime permissions. Invocation may be a slash command, natural-language request or app-specific action.
+
+The portable package is distributed in v1.97.13; complete new-app workflows remain unverified. Read [app limits](../../docs/HARNESS-PORTABILITY.md) before claiming a copied workflow works. Claude-specific hooks, subagents and frontmatter below apply only where the host supports them.
+
 **Purpose:** User-facing commands following the [Agent Skills](https://agentskills.io) standard for invoking workflows, tools, and features.
 
 ---
 
 ## What Are Skills?
 
-**Skills** are commands that extend what Claude can do - like giving Claude new capabilities. Each skill is a set of instructions for a specific workflow.
+**Skills** are instructions that help your AI assistant carry out a defined workflow.
 
-Think of skills as **expert modes** for Claude. Just like you'd switch to a specialized tool for a specific job, skills equip Claude with domain expertise, workflows, and tooling for particular tasks.
+Think of skills as **expert modes** for your assistant. Just like you'd switch to a specialized tool for a specific job, skills equip the assistant with domain expertise, workflows, and tooling for particular tasks.
 
 ### The Power of Skills
 
-Skills transform Claude from general-purpose assistant into specialized agent:
+Skills give a general-purpose assistant a defined workflow:
 
 **Without skills:**
 - "Can you help me plan my day?"
-- Claude makes educated guesses about what you want
+- The assistant makes educated guesses about what you want
 - Results vary, require back-and-forth clarification
 
 **With skills:**
 - `/daily-plan`
-- Claude knows exactly what to do: check calendar, review tasks, analyze priorities, generate structured plan
-- Consistent, reliable, no explanation needed
+- The skill describes what to do: check calendar, review tasks, analyze priorities, generate structured plan
+- A repeatable process that can report missing sources or tools
 
 **Real examples:**
 - `/career-coach` - Personal career coaching with 4 specialized modes (weekly reports, monthly reflections, self-reviews, promotion assessments)
@@ -34,11 +38,11 @@ Skills transform Claude from general-purpose assistant into specialized agent:
 
 **Simple version:**
 1. Skills live in this folder as instruction files
-2. You run a skill by typing `/skill-name` (like `/daily-plan`)
-3. Claude reads the instructions and follows them
+2. Invoke the installed skill using the app's supported action (for example `/daily-plan` in Claude Code)
+3. Your assistant reads the instructions and uses the available tools
 4. You get the result
 
-**Example:** When you type `/daily-plan`, Claude:
+**Example:** With the full planning skill and its services available, Dex:
 - Checks your calendar for today's meetings
 - Reviews your task list
 - Looks at your weekly priorities
@@ -50,7 +54,7 @@ Skills follow the [Agent Skills](https://agentskills.io) standard - a universal 
 
 **Two parts:**
 
-**1. Metadata** (at the top, tells Claude about the skill):
+**1. Metadata** (at the top, tells the assistant about the skill):
 ```yaml
 ---
 name: daily-plan
@@ -74,7 +78,7 @@ description: Generate context-aware daily plan with calendar and tasks
 
 **Benefits:**
 - **Reusable** - run the same workflow anytime
-- **Consistent** - same result every time
+- **Consistent** - a defined process whose outcome still depends on tools and sources
 - **Organized** - each skill has its own space
 - **Shareable** - works across AI assistants following Agent Skills standard
 

--- a/06-Resources/Dex_System/Background_Processing_Guide.md
+++ b/06-Resources/Dex_System/Background_Processing_Guide.md
@@ -1,40 +1,24 @@
 # Background Processing Guide
 
-Some skills take minutes, not seconds. Background processing lets you keep working while heavy operations run.
+Dex can do work during a conversation or through a separately installed job. The app you use determines whether a conversational workflow can continue in the background.
 
-## How It Works
+## Conversation work
 
-### Claude Code CLI
-Background agents run in a separate process. The skill acknowledges immediately and processes in the background. You get a notification when done.
+Claude Code supports background agents; use them only when the workflow and permissions permit it. In other apps, ask for progress in the current conversation unless background execution has been verified. A skill file does not create that execution capability.
 
-### Cursor
-Background execution works differently — skills provide progress updates during execution and break large batches into smaller chunks with intermediate output.
+The portable package distributed in v1.97.13 has read-only context tools and limited hook adapters. It does not install a meeting processor, task writer, session-end recorder or background service. Complete new-app journeys remain unverified; see [app capabilities](../../docs/HARNESS-PORTABILITY.md).
 
-## Candidate Skills
+## Scheduled work
 
-| Skill | Why Background | Typical Duration |
-|-------|---------------|-----------------|
-| `/process-meetings` | Heavy I/O, no interaction needed | 2-5 min for 5+ meetings |
-| `/review-article` | 22 parallel subagents | 3-8 min |
-| Intel pipelines (YouTube, Newsletter) | External API calls | 1-3 min each |
+Existing macOS jobs, such as meeting sync and optional Obsidian sync, run through the operating system after separate setup. They are independent of whether a chat is open. Installing or removing an app plugin does not start or stop those jobs. Check their configured schedule and health before expecting automatic results.
 
-## Design Pattern
+## What to expect
 
-All background-capable skills follow this pattern:
+- **Automatic:** a configured schedule or trusted app event runs the action. Identify which one.
+- **On demand:** request a workflow using its available skill and tools.
+- **Guided:** follow explicit steps where the app cannot complete the operation.
+- **Unavailable:** the current app or runtime cannot perform it; retain the existing working route.
 
-1. **Acknowledge** — Tell the user what's happening and how long to expect
-2. **Process** — Do the work silently
-3. **Summarize** — Report what was done with key metrics
+Syncing a meeting into the vault and processing its follow-ups are separate steps. A notification that meetings are waiting is not proof that tasks or person pages were updated. Ask for the saved result and check which sources were used.
 
-## When NOT to Use Background
-
-- Interactive skills that need user input mid-flow
-- Quick operations (<30 seconds)
-- Skills where the user needs to review output immediately
-
-## Implementation Notes
-
-- Skills declare background capability in their prompt
-- The harness (Claude Code / Cursor) decides execution model
-- Progress can be written to a status file for polling
-- Background skills should be idempotent — safe to re-run if interrupted
+See [the hook inventory](../../docs/architecture/HOOK-INVENTORY.md) for the exact separation between schedules, in-chat events and file writers.

--- a/06-Resources/Dex_System/Calendar_Setup.md
+++ b/06-Resources/Dex_System/Calendar_Setup.md
@@ -1,5 +1,7 @@
 # Connect Google Calendar to Dex (Mac)
 
+**Execution boundary:** this route uses macOS Calendar permissions in the app/runtime that actually runs Dex. A plugin or folder grant alone does not grant calendar access. The portable read-only package does not bundle the calendar integration; new-app calendar journeys need their own verification.
+
 This guide is for **Mac users** who use **Google Calendar** and want Dex to show their real meetings—including recurring ones like weekly 1:1s—when they run `/daily-plan` or ask "what's on my calendar today?"
 
 **Windows users:** Calendar connection is supported on Mac via Apple Calendar. This repo doesn't include Windows instructions yet.

--- a/06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md
+++ b/06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md
@@ -1,5 +1,7 @@
 # Dex: Jobs to Be Done
 
+Your vault holds the durable work; your chosen AI app helps you use it. The outcomes below describe the full Dex setup, not a guarantee that every app can perform every step. See [app and vault choice](../../README.md) and [capability modes](../../docs/HARNESS-PORTABILITY.md#capability-truth). New-app install and workflow support remains unverified even though portable package files are distributed in v1.97.13.
+
 **What this system actually does, and why each piece exists.**
 
 This document explains the purpose behind your Dex system. If you're new to the system, start here to understand what problems it solves. As you customize and extend Dex, this document evolves with you.
@@ -12,13 +14,13 @@ This document explains the purpose behind your Dex system. If you're new to the 
 
 A personal knowledge system that handles the cognitive overhead of professional life. Notes find their home. Tasks don't slip through cracks. People stay tracked. Your days start focused and end with reflection.
 
-The AI (Claude) acts as your knowledge assistant - helping you capture, organize, and act on information without drowning in process.
+Your chosen AI assistant acts as your knowledge assistant - helping you capture, organize, and act on information without drowning in process.
 
 ### What Makes It Different
 
 Traditional note systems are passive filing cabinets. Dex is active:
 
-- **AI-augmented**: Claude helps process, organize, and surface information
+- **AI-augmented**: Dex helps process, organize, and surface information
 - **Workflow-driven**: Commands guide you through daily and weekly rhythms
 - **Task-aware**: MCP server ensures tasks are validated, deduplicated, and prioritized
 - **Adaptable**: Pillars and structure customize to your role and priorities
@@ -43,13 +45,13 @@ Each job represents something that needs to happen reliably. The system exists t
 
 | Component | What It Does |
 |-----------|--------------|
-| Conversational capture | Just tell Claude things naturally - "Sarah worried about timeline but interested in Q2 pilot" |
+| Conversational capture | Tell Dex things naturally - "Sarah worried about timeline but interested in Q2 pilot" |
 | Strategic routing | Uses your Week Priorities and Quarterly Goals to suggest routing in real-time |
-| Immediate suggestions | Claude: "Should I add this to Sarah's person page and Q2 Planning project?" |
+| Immediate suggestions | Dex: "Should I add this to Sarah's person page and Q2 Planning project?" |
 | Work MCP for tasks | "Create task to finalize pricing" → validates, checks duplicates, writes to Tasks.md |
 | `/triage` for cleanup | Finds orphaned files and scattered tasks, routes strategically |
 
-**Example Flow**: You mention "Sarah seemed worried about timeline but interested in Q2 pilot". Claude immediately suggests: "I see you have 'Sarah's team onboarding' and 'Q2 Planning' in your Week Priorities. Should I add this to Sarah's person page and the Q2 Planning project?" You approve, it's filed. One decision, instant routing.
+**Example Flow**: You mention "Sarah seemed worried about timeline but interested in Q2 pilot". Dex suggests: "I see you have 'Sarah's team onboarding' and 'Q2 Planning' in your Week Priorities. Should I add this to Sarah's person page and the Q2 Planning project?" You approve, it's filed. One decision, instant routing.
 
 ---
 
@@ -83,7 +85,7 @@ Each job represents something that needs to happen reliably. The system exists t
 |-----------|--------------|
 | `People/` folder | One page per person with aggregated context |
 | `Companies/` folder | Organization-level aggregation of people, meetings, tasks |
-| Person lookup skill | Claude checks People folder first before any search |
+| Person lookup skill | Dex checks the People folder first before any search |
 | Meeting capture | Identifies people mentioned, updates their pages |
 | `/meeting-prep` command | Surfaces context about attendees before calls |
 | `refresh_company` tool | Pulls all related context into company page |
@@ -128,11 +130,11 @@ For organization-level context, check company pages in `05-Areas/Companies/`. Sh
 | `/journal` command | Morning, evening, or weekly reflection prompts |
 | `/review` command | End-of-day synthesis of what happened, captures learnings |
 | `/week` command | Weekly pattern recognition and planning |
-| Background changelog monitor | Checks every 6 hours for Claude updates, alerts you automatically |
+| Background changelog monitor | Installed macOS job checks every 6 hours for Claude Code updates; configured session hooks deliver the notice |
 | Learning review prompts | Daily check: when 5+ learnings pending, reminds you to review |
 | `Mistake_Patterns.md` | Logged mistakes become rules that prevent repetition |
 | `Working_Preferences.md` | Collaboration style captured and applied consistently |
-| Session learnings capture | Automatic logging in `System/Session_Learnings/` |
+| Session learnings capture | Logging in `System/Session_Learnings/` through configured Claude Code hooks; guided capture elsewhere |
 
 **v1.11.0**: Learning heartbeat now focused on operational knowledge only. Preferences are handled by Claude's built-in memory, so session learnings are cleaner and less noisy.
 
@@ -333,7 +335,7 @@ This document evolves as your Dex grows. When you:
 - Build automations, document what job they address
 - Discover workflow gaps, that might be a job waiting to be served
 
-The Documentation Sync behavior in CLAUDE.md ensures this stays current.
+Maintainers keep this guide aligned with shipped behavior; app instructions do not prove automatic documentation updates.
 
 ---
 

--- a/06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md
+++ b/06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md
@@ -129,7 +129,8 @@ For organization-level context, check company pages in `05-Areas/Companies/`. Sh
 |-----------|--------------|
 | `/journal` command | Morning, evening, or weekly reflection prompts |
 | `/review` command | End-of-day synthesis of what happened, captures learnings |
-| `/week` command | Weekly pattern recognition and planning |
+| `/week-review` command | Review accomplishments and patterns from the week |
+| `/week-plan` command | Set priorities for the week ahead |
 | Background changelog monitor | Installed macOS job checks every 6 hours for Claude Code updates; configured session hooks deliver the notice |
 | Learning review prompts | Daily check: when 5+ learnings pending, reminds you to review |
 | `Mistake_Patterns.md` | Logged mistakes become rules that prevent repetition |
@@ -138,7 +139,7 @@ For organization-level context, check company pages in `05-Areas/Companies/`. Sh
 
 **v1.11.0**: Learning heartbeat now focused on operational knowledge only. Preferences are handled by Claude's built-in memory, so session learnings are cleaner and less noisy.
 
-**Example Flow**: Friday afternoon, run `/week`. Dex synthesizes the week: themes that emerged, energy patterns (what energized vs drained you), progress by project, questions that came up. You spot a pattern - every meeting with Team X drains energy. That's useful data for next week's planning.
+**Example Flow**: Friday afternoon, run `/week-review`. Dex synthesizes the week: themes that emerged, energy patterns (what energized vs drained you), progress by project, questions that came up. You spot a pattern - every meeting with Team X drains energy. That's useful data for next week's planning with `/week-plan`.
 
 During the week, you mentioned "I prefer summaries in bullet points." Dex captured this in Session_Learnings and now asks: "You've mentioned this preference 3 times. Add to Working_Preferences.md so all future summaries use bullets?"
 

--- a/06-Resources/Dex_System/Dex_System_Guide.md
+++ b/06-Resources/Dex_System/Dex_System_Guide.md
@@ -1,5 +1,11 @@
 # Dex System Guide
 
+Dex is one personal system: your notes, priorities and saved work live in the vault; your AI app connects to it. Start with [choose your app and vault](../../README.md), then ask for one useful outcome: "Plan my day from my priorities and tasks; tell me which sources you can read."
+
+**Scope:** the complete workflows below describe the established full-vault setup, with Claude Code-specific automation named where used. Slash commands require the corresponding installed skill and tools. A portable skill file alone does not supply task writes, meeting follow-through, Doctor or updates. The v1.97.13 portable package is distributed; complete supported new-app journeys remain unverified. See [app capabilities](../../docs/HARNESS-PORTABILITY.md#capability-truth).
+
+Automatic means a configured, trusted event runs the behavior; on demand means you ask; guided means you complete explicit steps; unavailable means the surface cannot deliver it. Missing sources or services must be reported before claiming an outcome.
+
 **Personal Reference** — Full documentation for your Dex knowledge system.
 
 ---
@@ -8,7 +14,7 @@
 
 ```
 Morning    → Run /daily-plan for context-aware daily planning
-During day → Just tell Claude things - it routes them intelligently
+During day → Tell Dex things - it routes them intelligently
 After mtgs → Dex extracts action items and updates person pages
 As needed  → /triage finds orphaned files and scattered tasks
 End of day → Run /daily-review
@@ -29,13 +35,13 @@ End of week → Run /week-review
 
 **Conversational Capture:**
 
-Just tell Claude things naturally:
+Tell Dex things naturally:
 
 | What You Do | What Happens |
 |-------------|--------------|
-| "Sarah was worried about timeline but interested in Q2 pilot" | Claude suggests: "Add to Sarah's person page and Q2 Planning project?" |
+| "Sarah was worried about timeline but interested in Q2 pilot" | Dex suggests: "Add to Sarah's person page and Q2 Planning project?" |
 | "Create a task to finalize mobile app pricing" | Work MCP validates, checks duplicates, writes to Tasks.md |
-| "Random idea: could we automate weekly reports?" | Claude suggests where to file it based on your priorities |
+| "Random idea: could we automate weekly reports?" | Dex suggests where to file it based on your priorities |
 
 The system uses your Week Priorities and Quarterly Goals to route intelligently in real-time.
 
@@ -59,7 +65,7 @@ Creates reflection on:
 ### End of Week
 
 ```
-/week
+/week-review
 ```
 
 Creates weekly synthesis:
@@ -82,8 +88,8 @@ All skills are documented in detail in the **Skills System** section below. Here
 2. Optional: `/meeting-prep` — Prepare for first meeting
 
 **During Day:**
-- Tell Claude things naturally → it routes intelligently based on your priorities
-- "Sarah worried about timeline" → Claude suggests person page + project routing
+- Tell Dex things naturally → it routes intelligently based on your priorities
+- "Sarah worried about timeline" → Dex suggests person page + project routing
 - "Create task to finalize pricing" → Work MCP validates and adds to Tasks.md
 
 **End of Day:**
@@ -183,7 +189,7 @@ Triage is a cleanup tool that finds orphaned files and scattered tasks, then rou
 - Scattered `- [ ]` tasks across multiple notes
 - Periodic cleanup and routing
 
-**Note:** For most capture, just tell Claude things conversationally. Triage is for cleanup, not primary workflow.
+**Note:** For most capture, just tell Dex things conversationally. Triage is for cleanup, not primary workflow.
 
 ### How It Works
 
@@ -450,7 +456,7 @@ Dex checks if Anthropic has released new Claude Code features. When it finds som
 **Learning Review Prompts (daily at 5pm)**  
 As you work, Dex captures learnings in `System/Session_Learnings/`. When you accumulate 5+ learnings that haven't been reviewed yet, Dex reminds you: "📚 You have 7 pending learnings from this week. Worth reviewing?"
 
-Both happen automatically with no action from you. The system stays current on its own.
+These checks depend on the separately installed schedules and Claude Code notification hooks. A portable plugin installation starts neither; ask for a review where automatic delivery is unavailable.
 
 ### Learning Files
 
@@ -492,18 +498,18 @@ With automation, Dex nudges you at the right time. The system improves itself th
 
 **The Problem:** You're reading a meeting note that mentions "Sarah." Who is Sarah? What did you discuss last time? What's she working on?
 
-**What Dex Does:** Automatically loads relevant context in the background so you don't have to go hunting for it.
+**In configured Claude Code:** read hooks supply relevant context. Other surfaces can request person context on demand if that tool is registered; company injection is not part of the four-tool portable package.
 
 ### Smart Context Loading
 
 When you're reading any file that mentions people or companies, Dex quietly:
 - Looks up their person page or company page
 - Loads recent meeting history, action items, and relationship notes
-- Makes that information available to Claude in the background
+- Makes that information available to your assistant in the background
 
 This context comes from the real person and company pages in your vault. In Obsidian mode, names in meeting notes are linked to those pages using their actual paths, so a link always opens the page Dex found.
 
-You don't see any headers or popups - it just works. When you ask "What did Sarah and I discuss last week?", Claude already knows because it loaded her context automatically.
+You don't see any headers or popups - it just works. When you ask "What did Sarah and I discuss last week?", Dex can use the context supplied by the configured Claude Code hook.
 
 **Example:** You open a meeting note from a customer call. The note mentions "Acme Corp." Dex automatically loads the Acme Corp company page, sees you've had 5 meetings with them in the past month, notices there are 3 open action items, and uses that context to help you prepare better.
 
@@ -784,7 +790,7 @@ Skills are reusable AI workflows invoked with `/skill-name`. All skills follow t
 
 ### How Skills Work
 
-Skills define consistent behaviors Claude follows. When you type `/skill-name`, Claude reads the skill file at `.claude/skills/[skill-name]/SKILL.md` and follows its instructions.
+Skills define workflows for your assistant. Where slash commands are supported, your assistant loads the installed skill and follows its instructions. The canonical source is `.claude/skills/[skill-name]/SKILL.md`; generated copies serve other apps.
 
 ---
 
@@ -846,7 +852,7 @@ Meetings with attendees from these email domains will appear in Meeting History.
 
 ### How Skills Work
 
-Skills define consistent behaviors Claude follows. When a skill is relevant, Claude applies its protocol automatically.
+Skills define workflows for your assistant. Discovery and invocation depend on the app; confirm the skill and its required tools are available.
 
 ---
 
@@ -1170,7 +1176,7 @@ Complexity scales with your organization size (set during onboarding):
 
 ## Maintenance
 
-This guide stays current through the Documentation Sync behavior in CLAUDE.md. When significant system changes happen (new commands, behaviors, workflows), this guide updates automatically.
+Maintainers update this guide when shipped behavior changes and copy it byte-for-byte to the compatibility documentation tree. An instruction in CLAUDE.md is not evidence that documentation updated itself.
 
 **Rule of thumb**: If someone reading only this guide would miss something important about how to use the system, it needs updating.
 

--- a/06-Resources/Dex_System/Dex_Technical_Guide.md
+++ b/06-Resources/Dex_System/Dex_Technical_Guide.md
@@ -1,5 +1,9 @@
 # Dex Technical Guide
 
+**Scope, v1.97.13:** this guide describes the full Core/vault installation and retains Claude Code-specific examples. Portable package distribution is released; complete supported new-app journeys are unverified. The four-tool package does not include Work MCP mutation workflows, onboarding, Doctor, updates, feedback or session-end capture. [Exact surface limits](../../docs/HARNESS-PORTABILITY.md).
+
+Shared vault semantics, an app adapter and the model doing the reasoning are separate boundaries. An adapter translates selected-folder access, tool registration and verified events; it does not make every Core service available. Agent Skills syntax alone proves neither execution dependencies nor workflow results. OS jobs require separate installation; app hooks require their actual event, runtime and trust configuration.
+
 **Version:** 1.0  
 **Last Updated:** July 2026
 
@@ -21,7 +25,7 @@
 10. [Design Constraints](#design-constraints)
 
 **Related Guides:**
-- [Cursor Compatibility](Cursor_Compatibility.md) - Working with both Cursor and Claude Code
+- [App capability guide](../../docs/HARNESS-PORTABILITY.md) - Working with both Cursor and Claude Code
 
 ---
 
@@ -780,7 +784,7 @@ when it creates a task for you.
    - Person pages: Add meeting reference + action items
    - Career folder: If manager 1:1, save feedback to `05-Areas/Career/Evidence/`
 
-**User experience:** Meetings auto-sync. Dex notices waiting meetings at the start of a session — synced from Granola or captured by hand — and processes them in the background automatically. Nothing appears when there is nothing to do. You can still run `/process-meetings` directly whenever you want to review or triage meetings yourself.
+**User experience:** Configured meeting-sync jobs import meetings. The Claude Code session hook can announce waiting meetings; processing requires its skill, services and configured permissions. A queue notice is not proof of completed follow-ups. Run `/process-meetings` in the established full-vault setup to review or triage them. This workflow is not supplied by the portable read-only bridge.
 
 ### Why MCP for Integrations?
 
@@ -1193,7 +1197,7 @@ Understanding these constraints explains why Dex is designed the way it is.
 - `CLAUDE.md` - Main AI behavior instructions
 - `System/user-profile.yaml` - User preferences, company info, communication style
 - `System/pillars.yaml` - Strategic pillars (focus areas)
-- `.claude/settings.json` - Cursor settings (MCP server configs)
+- `.claude/settings.json` - Claude Code hook and permission settings
 
 ### Skills
 

--- a/06-Resources/Dex_System/Distribution_Checklist.md
+++ b/06-Resources/Dex_System/Distribution_Checklist.md
@@ -1,5 +1,17 @@
 # Dex Distribution Checklist
 
+## App support evidence (v1.97.13 baseline)
+
+Portable package files are distributed in v1.97.13. Distribution does not certify a host. Before adding a supported app CTA to GitHub or heydex.ai, retain exact version, artifact checksum, app/surface and OS evidence for:
+
+- New and existing/customized vault install, prerequisites and folder grants.
+- First useful plan, person/meeting context, task create/complete and meeting follow-through; missing optional integrations must be explicit.
+- Actual hook trust, denied permissions, conflicting roots, offline behavior and guided fallbacks.
+- Feedback preview/submission, update/rewind, disable/remove and preserved vault content.
+- Required CI and reviews, plus a real installed native app journey. A subprocess protocol test alone is insufficient.
+
+Keep GitHub and website install/help routes consistent. Verify the served artifact separately from local source. Complete new-app support evidence is pending; do not convert candidate registry modes into support badges.
+
 **Last Updated:** 2026-07-26 (v1.75.2)
 
 Maintainer reference for how Dex ships and what to check when cutting a release.
@@ -27,7 +39,7 @@ authoritative, CI-drift-gated list (names, tool counts, exact tools) is
 `docs/architecture/INVENTORY.md` § "MCP engines" — don't hand-copy it here.
 
 External MCPs (browser automation, user-installed integrations, hosted vendor
-MCPs) are not part of Dex; users add them via their own Claude settings.
+MCPs) are not part of Dex; users add them through their chosen app's supported integration settings.
 
 Optional companions degrade gracefully:
 - **Granola** — meeting sync uses Granola's official public API with

--- a/06-Resources/Dex_System/Distribution_Strategy.md
+++ b/06-Resources/Dex_System/Distribution_Strategy.md
@@ -1,5 +1,11 @@
 # Dex Distribution Strategy
 
+## Current distribution boundary
+
+The current route distributes the full vault/product bundle plus host-specific portable artifacts. Package files are present in v1.97.13; complete supported journeys for new apps remain unverified. Preserve established full-vault users while certifying each app's install, first outcome, permissions, update and removal separately. Use the [current checklist](Distribution_Checklist.md) and [app guide](../../docs/HARNESS-PORTABILITY.md) for that evidence.
+
+The January design record below is historical; its Git merge and customization mechanics are not current install instructions.
+
 **Status: HISTORICAL (January 2026) — mechanisms superseded.** The philosophy below
 ("Dex is yours, not ours"; updates enhance without disrupting) still holds, but the
 git-upstream merge mechanics this document describes were replaced in mid-2026 by

--- a/06-Resources/Dex_System/Folder_Structure.md
+++ b/06-Resources/Dex_System/Folder_Structure.md
@@ -1,5 +1,7 @@
 # Dex Folder Structure (PARA Method)
 
+The vault layout is shared across apps. Open the existing vault when changing apps; do not recreate it. Product instructions such as `CLAUDE.md` belong to a specific app surface, while your notes, people, tasks and priorities remain yours. Automatic filing and scheduled work below require their configured full-vault services; a portable plugin alone does not enable them.
+
 Dex uses the PARA method for organization: **Projects**, **Areas**, **Resources**, and **Archives**.
 
 ## What is PARA?
@@ -165,7 +167,7 @@ Archives = historical record, rarely consulted
 
 ### Auto-Archiving
 
-Plans and reviews automatically move here:
+Configured archive workflows move plans and reviews here:
 - Daily reviews → after `/daily-review` runs
 - Weekly plans → after `/week-plan` runs
 - Weekly reviews → after `/week-review` runs
@@ -234,7 +236,7 @@ System/
 
 Most users won't edit this directly—Dex manages it. But when you want to adjust strategic direction or preferences, the key files are here.
 
-**Background automation:** Dex also includes scripts in `.scripts/` that run automatically:
+**Background automation:** Dex includes scripts in `.scripts/` that run after their operating-system jobs have been separately installed and enabled:
 - `meeting-intel/sync-from-granola.cjs` — Syncs meetings, records attendee emails and locations, creates or suggests eligible people and companies, and verifies entity coverage. In Obsidian mode, names link to their actual person pages.
 - `check-anthropic-changelog.cjs` — Checks for Claude updates every 6 hours
 - `learning-review-prompt.sh` — Daily 5pm check for pending learnings

--- a/06-Resources/Dex_System/Memory_Ownership.md
+++ b/06-Resources/Dex_System/Memory_Ownership.md
@@ -1,27 +1,19 @@
 # Memory Ownership Boundaries
 
-## Claude Auto-Memory (native)
-**Owns:** Preferences, style, communication patterns, formatting choices
-**Examples:** "User prefers bullet points", "Use neutral mermaid theme", "Direct communication style"
-**How it works:** Automatically captured by Claude. Persists across all sessions and harnesses.
-**Dex action:** Don't duplicate. Don't capture preferences in learning-heartbeat.
+Your saved Dex work belongs to the vault. An AI app's native memory, conversation history and model context are separate stores; changing apps does not automatically transfer them.
 
-## Agent Memory (frontmatter, `memory: project`)
-**Owns:** Per-agent operational state across sessions
-**Examples:** "deal-attention flagged Acme Corp 3 times", "cracks-detector: pricing follow-up resolved"
-**How it works:** Each agent reads/writes its own memory. Scoped to that agent.
-**Dex action:** Configured in Phase 1, WP-1.1.
+## App-native memory
 
-## Dex Session Memory (learning-heartbeat)
-**Owns:** Operational decisions, commitments, work patterns, system learnings
-**Examples:** "Agreed to deliver DACH deck by Friday", "Meeting-prep skill needs more account context"
-**How it works:** Captured at session Stop, stored in System/Session_Learnings/
-**Dex action:** Filter for operational only (WP-2.1).
+Claude Code auto-memory may retain preferences and project knowledge when enabled in that host. Its scope and availability are host-owned. It does not persist across all AI apps by virtue of installing Dex. Keep preferences you want Dex to reuse in your vault profile or an explicitly saved note.
 
-## Dex Vault Search (QMD)
-**Owns:** Semantic search across all vault content
-**Dex action:** Unchanged.
+Agent-specific `memory: project` is also a host feature. A copied skill or agent instruction does not establish equivalent memory elsewhere.
 
-## Dex Proactive Intelligence (Phase 4 — planned)
-**Owns:** Anticipation, pre-fetching, pattern prediction across agents
-**Dex action:** Future. Enhanced by agent memory providing richer signal.
+## Dex session learnings
+
+Operational decisions, commitments and reusable lessons can be saved in `System/Session_Learnings/` by the configured full-vault workflows. Claude Code has session-related capture hooks; the v1.97.13 portable package does not include a session-end capture adapter. In a new app, ask for a summary and confirm whether saving is available. Do not claim a memory was stored until the saved result is read back.
+
+## Search and context
+
+Vault search indexes existing content when its search service is configured. The portable `boot_today` and `get_person_context` tools read selected vault files; they do not record the current conversation. A missing index, ungranted folder or unavailable tool must be reported as such.
+
+Vault files are local, but an AI app may send the context it reads to its model provider. Folder access, connected-service permissions and feedback consent remain separate decisions. See [app limits](../../docs/HARNESS-PORTABILITY.md) and [the system guide](Dex_System_Guide.md).

--- a/06-Resources/Dex_System/Named_Sessions_Guide.md
+++ b/06-Resources/Dex_System/Named_Sessions_Guide.md
@@ -1,5 +1,7 @@
 # Named Sessions
 
+**Claude Code-specific.** The `/rename` and `claude --resume` examples below use Claude Code's conversation store. They are not portable Dex commands. In another app, use that app's conversation controls; only work explicitly saved in the vault is shared. New-app session continuity remains unverified.
+
 Pick up exactly where you left off. Named sessions keep full conversation history so you never re-explain context.
 
 ---

--- a/06-Resources/Dex_System/Obsidian_Guide.md
+++ b/06-Resources/Dex_System/Obsidian_Guide.md
@@ -1,5 +1,7 @@
 # Using Dex with Obsidian
 
+Obsidian reads the same local vault independently of your AI app. Wiki-link migration and cross-file task sync are separate Dex services: they require setup and are not enabled merely by opening the folder or installing a portable plugin. See [app limits](../../docs/HARNESS-PORTABILITY.md).
+
 Obsidian is a free markdown editor with powerful graph visualization. It's completely optional, but many users love seeing their knowledge as a connected graph.
 
 **New to Obsidian?** Watch this [beginner's guide (5 min)](https://www.youtube.com/watch?v=gafuqdKwD_U) to see what it can do.
@@ -23,7 +25,7 @@ Obsidian is a free markdown editor with powerful graph visualization. It's compl
 
 1. Download Obsidian (free): https://obsidian.md
 2. Open your Dex vault: File → Open Folder → Select your Dex directory
-3. Enable Obsidian mode: Run `/dex-obsidian-setup` in Cursor/Claude
+3. Enable Obsidian mode: Run `/dex-obsidian-setup` in your established Cursor or Claude Code setup
 
 ## Obsidian vs Terminal/Cursor
 
@@ -37,7 +39,7 @@ Both are first-class experiences:
 | AI integration | ❌ Limited | ✅ Native |
 | Speed | ⚡ Fast | ⚡⚡ Faster |
 
-**Recommendation:** Use both! Obsidian for visual navigation and reading, Cursor/Claude for AI-powered workflows.
+**Recommendation:** Use both! Obsidian for visual navigation and reading, your configured AI app for Dex workflows.
 
 ## Setting Up Later
 

--- a/06-Resources/Dex_System/README.md
+++ b/06-Resources/Dex_System/README.md
@@ -1,28 +1,23 @@
-# Dex System
+# Dex system guides
 
-Documentation about how Dex works and why.
+Start with the [system guide](Dex_System_Guide.md) for planning, meetings, people and tasks, or [jobs to be done](Dex_Jobs_to_Be_Done.md) for why those workflows exist. Dex is your durable personal system; the AI app is how you work with it.
 
-## What Goes Here
+For app choice, new or existing vault setup and the first useful result, use the [repository entry guide](../../README.md). Claude Code and Cursor retain their established full-vault routes. Portable files are distributed in v1.97.13; complete new-app journeys remain unverified. [Exact app limits](../../docs/HARNESS-PORTABILITY.md).
 
-- **Dex_Jobs_to_Be_Done.md** — Why the system exists, what problems it solves
-- **Dex_System_Guide.md** — Comprehensive guide to using Dex effectively
-- **Integrations/** — Setup guides for external tools (Granola, Pendo, etc.)
+[Updating and recovery](Updating_Dex.md) · [Background processing](Background_Processing_Guide.md) · [Memory ownership](Memory_Ownership.md) · [Obsidian](Obsidian_Guide.md).
 
-## Purpose
+## Documentation ownership
 
-This folder contains the "why" and "how" of Dex itself. When you forget how something works or want to understand the design philosophy, start here.
+`docs/Dex_System/` is the Brain-owned home for Dex's shipped system guides.
 
-## Key Documents
+For this transition release, the same guides remain under
+`06-Resources/Dex_System/` so existing links and combined-layout installs keep
+working. Those legacy copies are temporary bridge files; the updater flow will
+complete the physical move later without treating the rest of `06-Resources/`
+as Dex-owned.
 
-- **Jobs to Be Done** — Understand what problems Dex solves and when to use each feature
-- **System Guide** — Complete walkthrough of workflows, commands, and best practices
-- **Integration guides** — Connect external tools to enhance Dex
+Until that move lands:
 
-## Maintenance
-
-These docs are living documents:
-- Updated when the system changes
-- Refined based on user feedback
-- Expanded as new features are added
-
-If you find gaps or unclear sections, mention them and Dex will update the docs.
+- use `docs/Dex_System/` as the canonical shipped documentation tree;
+- keep `06-Resources/Dex_System/` in place for compatibility;
+- do not move personal notes from `06-Resources/` into this Brain-owned tree.

--- a/06-Resources/Dex_System/Updating_Dex.md
+++ b/06-Resources/Dex_System/Updating_Dex.md
@@ -1,5 +1,17 @@
 # Updating Dex — Explained Simply
 
+## Choose the update route for your installed setup
+
+Dex product files, your personal vault and the AI app's plugin have separate lifecycles. In an established full-vault setup, use `/dex-update` (or ask for the update preview) with the configured Dex lifecycle service. Start from the same vault you already use; do not create another vault to update or switch apps.
+
+The v1.97.13 portable package exposes four read-only/advisory tools; it does not bundle the installer, updater, Doctor or rollback service. A generated update skill does not supply those dependencies. Complete new-app update and removal journeys remain unverified. Use your existing working app for vault updates until [the app-specific route](../../docs/HARNESS-PORTABILITY.md) has native proof.
+
+Automatic release notices depend on configured Claude Code session hooks. Elsewhere, ask to check the release explicitly if that service is available. A notice is never approval to install.
+
+To leave an app, close its Dex session and disable its plugin or revoke its folder grant. Keep your vault to retain your notes. Independently installed jobs and connected accounts need separate controls; removing a plugin does not disable them. No new-app removal command is certified by this guide.
+
+The receipt-backed flow below applies when the full lifecycle service is available. Rewind requires an eligible receipt and successful safety checks; it is not an unconditional undo of every file or app change.
+
 **Last Updated:** July 26, 2026 (reflects the receipt-backed update system, v1.65+)
 
 This guide explains how Dex updates work, written for people who've never used

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 You've been using Dex. Maybe you fixed something that was bugging you. Maybe you built a new skill, connected a new tool, or wrote a guide that would've saved you an hour on day one. Whatever it is — Dave would love to see it.
 
-**You don't need to be a developer to contribute.** If you can use Dex, you can share improvements. Claude will help you with the technical bits.
+**You don't need to be a developer to contribute.** If you can use Dex, you can share improvements. Your AI assistant can help you with the technical bits.
 
 ---
 
@@ -24,11 +24,11 @@ Anything that makes Dex better for someone else:
 ### The simple version (recommended)
 
 1. **Make your changes in Dex as normal** — fix the bug, build the skill, write the guide
-2. **Ask Claude to help you share it.** Say something like:
+2. **Ask your AI assistant to help you share it.** Say something like:
 
    > "I made some improvements to Dex that I'd like to share back with the community. Can you help me create a pull request?"
 
-3. Claude will walk you through it — creating a branch, describing what you changed, and submitting it. You don't need to know what any of those words mean. Just follow along.
+3. Your assistant can walk you through it — creating a branch, describing what you changed, and submitting it. You don't need to know what any of those words mean. Just follow along.
 
 4. **Your changes appear on GitHub** for review. Dave will take a look, give feedback if needed, and merge it in.
 
@@ -37,7 +37,7 @@ Anything that makes Dex better for someone else:
    change. On forked pull requests where GitHub will not allow a bot comment, the
    same report remains available in the `pr-report` job summary.
 
-That's it. Claude handles the git mechanics. You just describe what you changed and why.
+That's it. Your assistant can help with the git mechanics. You just describe what you changed and why.
 
 ### What makes a good contribution
 
@@ -48,7 +48,7 @@ That's it. Claude handles the git mechanics. You just describe what you changed 
 
 ### What to avoid
 
-- **Personal data.** CI enforces this on every pull request by checking newly added lines for real emails, filled-in profile or integration identity, vault content, and other personal configuration. If the PII / personal-config gate fails, remove the named data, restore the tracked placeholder template, or replace examples with an approved fake value from `scripts/pii-allowlist.txt`; the failure prints the exact file and line. You can still ask Claude: "Can you check these files for any personal information before I share them?"
+- **Personal data.** CI enforces this on every pull request by checking newly added lines for real emails, filled-in profile or integration identity, vault content, and other personal configuration. If the PII / personal-config gate fails, remove the named data, restore the tracked placeholder template, or replace examples with an approved fake value from `scripts/pii-allowlist.txt`; the failure prints the exact file and line. You can still ask your assistant: "Can you check these files for any personal information before I share them?"
 - **Breaking existing features.** If you're not sure whether your change might affect something else, mention that in your description. Dave would rather know upfront than discover it later.
 
 ---
@@ -82,7 +82,7 @@ Describe:
 
 ## A Note on AI-Assisted Contributions
 
-Most Dex contributions are written with AI help — and that's not just OK, it's the point. Dex is an AI-powered system built by people who use AI daily. If Claude helped you write the code, that's great. Just make sure you understand what it does and that you've tested it.
+Most Dex contributions are written with AI help — and that's not just OK, it's the point. Dex is an AI-powered system built by people who use AI daily. If an AI assistant helped you write the code, that's great. Just make sure you understand what it does and that you've tested it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,101 +1,111 @@
 # Dex by Dave — Your AI Chief of Staff
 
-[![Latest release](https://img.shields.io/github/v/release/davekilleen/dex?label=release&color=2ea44f)](https://github.com/davekilleen/dex/releases) [![License: PolyForm Noncommercial](https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue)](LICENSE) [![Built for non-engineers](https://img.shields.io/badge/coding%20required-none-ff69b4)](https://heydex.ai/help/)
+[![Latest release](https://img.shields.io/github/v/release/davekilleen/dex?label=release&color=2ea44f)](https://github.com/davekilleen/dex/releases) [![License: PolyForm Noncommercial](https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue)](LICENSE)
 
-**A personal operating system for your work.** Strategic work management, meeting intelligence, relationship tracking, daily planning — all configured for your specific role. Claude Code remains the full-experience reference; the unreleased portability build adds native, capability-aware packages for more agent harnesses without pretending every host is identical. No coding required.
+**One personal Dex, built around your work.** Keep your priorities, people, meeting notes and tasks in a folder you own. Work with Dex through your AI app to plan the day, prepare for a meeting or follow through on a promise. Your saved work stays with your vault when you change apps.
+
+Start here or at [heydex.ai](https://heydex.ai/). The [Dex Guide](https://heydex.ai/help/) walks through setup and everyday use; the steps below keep the same starting point in GitHub.
 
 <p align="center">
-  <img src="docs/assets/dex-hero.gif" alt='Dex in action: "plan my day" scans your calendar, Slack, Salesforce, Granola and goals, then protects your morning — "what do I owe people?" finds every open promise and drafts the replies.' width="960">
+  <img src="docs/assets/dex-hero.gif" alt="Example Dex planning conversation with connected work sources; available sources depend on your setup." width="960">
 </p>
 
-**The story behind Dex:** 🎥 [Malleable Software — when everyone can build, what makes a great product?](https://www.youtube.com/watch?v=QcqBsxw9hQM) (Dave's keynote on the thinking behind Dex) · 🎙️ [Episode 8 of The Vibe PM Podcast](https://youtu.be/WaqgSvL-V10?si=b2Pfwf7I5rozWCo0) (full walkthrough) · ✍️ [the original launch post](https://www.linkedin.com/pulse/your-ai-chief-staff-building-personal-operating-system-dave-killeen-yxnqe/) · 💬 [the honest highs-and-lows of building it](https://www.linkedin.com/feed/update/urn:li:activity:7486431643524796418/) — the pause, the unlock, and 52 releases in two weeks
+## 1. Choose your AI app
 
-> 🖥️ **Prefer never to see a terminal?** Dex desktop and mobile apps are on the way — sign up for early access at **[heydex.ai/beta](https://heydex.ai/beta)**.
+| Your app | Route today |
+| --- | --- |
+| **Claude Code, terminal or Code tab in the desktop app** | Established full-vault route and reference for Dex's automatic session behavior. Use the install below, then open your Dex folder in Claude Code. [Claude Code primer](#claude-code-primer). |
+| **Cursor** | Established full-vault setup for prompted skills and configured tools. Use the install below or the [manual steps](#manual-setup-for-cursor). Do not assume Claude Code's hooks run in Cursor. |
+| **Codex CLI/desktop and other new app integrations** | Portable package files are distributed in **v1.97.13**. Complete supported install, workflow, update and removal journeys remain **unverified**. [Developer preview and exact limits](docs/HARNESS-PORTABILITY.md); no supported new-app install is promised here yet. |
 
-> ### 📖 New here? Start with the [Dex Guide →](https://heydex.ai/help/)
->
-> A plain-English walkthrough from install to making Dex your own, with
-> copy-paste prompts throughout — written for non-technical professionals, no
-> coding background assumed. The README below covers the same ground in
-> reference form. (AI agents: [llms.txt](https://heydex.ai/help/llms.txt).)
+The AI app and the model it uses are separate choices. App subscriptions, usage limits and optional connected services have their own costs; check your provider before signing up.
 
----
+## 2. Choose your vault
 
-## Setup Overview
+A **vault** is the folder containing your personal Dex notes and configuration.
 
-**Total time:** ~10 minutes. One pasted line installs everything, then you tell Dex your role.
+**Already use Dex?** Open your existing folder in the app you already use. Keep your notes, profile and custom skills; changing apps is not a reason to create another vault or repeat onboarding. A new app must be granted access to that same folder before it can use your work.
 
-**Pick one of these to get started:**
+**Starting fresh?** The established installer checks prerequisites and prepares `Documents/Dex`. Review its prompts before approving changes.
 
-| Option | Cost | What It Is | Dex tier |
-|--------|------|------------|----------|
-| **[Cursor](https://cursor.com)** | Free tier works, or $20/month for Pro | An app with a built-in AI assistant. No separate Claude account needed. | **Tier 2 Skills** — vault, tools, and named journeys |
-| **[Claude Code Desktop](https://claude.ai/download)** | Claude Pro $20/month | Anthropic's own app. The full Dex experience — hooks, automatic context, self-learning. | **Tier 3 Full** — the reference implementation |
-| **Claude Code Terminal** | Claude Pro $20/month | Same as Desktop but runs in Terminal (Mac) or PowerShell (Windows). | **Tier 3 Full** |
+### Quick install (Claude Code or Cursor)
 
-> **You do NOT go to claude.ai and type commands.** You need one of the apps above. Cursor is the easiest starting point. Claude Code (Desktop or Terminal) gives you a better experience with self-learning hooks — setup instructions for those are [further down this page](#want-guaranteed-hooks-use-claude-code-cli-or-desktop-app).
-
-**Not sure which?** Start with Cursor — it's free and gets you running in minutes. You can add Claude Code later if you want the automatic behaviors.
-
-### What you get with each assistant
-
-Dex is the vault and the tools. The app you talk to is a **harness**. What you get depends on which harness you use — that is a documented contract, not a silent subset.
-
-| Tier | Name | What you get | Who it's for |
-|------|------|--------------|--------------|
-| **Tier 0 Vault** | Your notes | Markdown folders (inbox, projects, people, tasks). Dex is just files. | Any editor. No AI required. |
-| **Tier 1 Core** | Tools + background jobs | Tasks, people index, meeting sync, search, and portable context/gate payloads. | Any assistant that can run Dex's MCP tools |
-| **Tier 2 Skills** | Named journeys | `/daily-plan`, `/process-meetings`, and the rest of the skill surface, generated into `.agents/`. | Any assistant that reads Agent Skills |
-| **Tier 3 Full** | Automatic in-chat behavior | Person context when you open a file, safety gates, session learning, and the mid-session health pulse. | **Claude Code today** — the reference implementation |
-
-Cursor, Codex, Gemini CLI, and other Agent Skills harnesses are Tier 2. The vault is always Tier 0. Cursor, ChatGPT, and Codex should call `boot_today` at session start and `get_person_context` when a person is mentioned. `check_safety_gate` is an advisory MCP check; only a verified pre-tool interceptor can enforce a refusal. The longer split is in [`docs/architecture/HARNESS-CAPABILITY.md`](docs/architecture/HARNESS-CAPABILITY.md) and [`docs/architecture/HOOK-INVENTORY.md`](docs/architecture/HOOK-INVENTORY.md).
-
-> **Unreleased portability preview:** this branch contains one portable plugin package for
-> Codex CLI/desktop, ChatGPT desktop, Claude Code/Cowork, Copilot CLI, and compatible
-> Agent Plugin clients; a native BB plugin is built separately; and Pi keeps its native
-> extension. The package shares Dex's read-only session context, person context, and
-> safety decision code. It has not been merged, published, submitted to a marketplace,
-> or released. Codex IDE extensions do not currently load plugins, and ChatGPT web/Cowork
-> connectors need a separately secured public endpoint before they can reach a local vault.
-> The developer-preview journeys and exact boundaries are in
-> [`docs/HARNESS-PORTABILITY.md`](docs/HARNESS-PORTABILITY.md).
-
----
-
-## Quick Install (Recommended)
-
-One pasted line checks your computer, installs anything missing (asking first), downloads Dex to `Documents/Dex`, and sets everything up. Safe to run more than once.
-
-**Mac** — press `Cmd+Space`, type "Terminal", press Enter, then paste this and press Enter:
+**Mac — Terminal:**
 
 ```bash
 curl -fsSL https://heydex.ai/install.sh | bash
 ```
 
-**Windows** — open the Start menu, type "PowerShell", press Enter, then paste this and press Enter:
+**Windows — PowerShell:**
 
 ```powershell
 irm https://heydex.ai/install.ps1 | iex
 ```
 
-**Or let your AI do the whole thing.** If you already use Claude, ChatGPT, or another AI assistant that can run things on your computer, just tell it:
+Then open the Dex folder in Claude Code or Cursor and say **"hi"**. Dex guides you through your role and priorities. [Installation help](https://heydex.ai/install/). If setup stops, keep the error message and use the help below; some prerequisites may already have been installed.
 
-> Install Dex on my computer. Follow the instructions at https://heydex.ai/install.md and walk me through anything you can't do yourself.
+## 3. Get one useful result
 
-When the installer finishes, open the Dex folder in Cursor or Claude Code, say **"hi"**, and Dex introduces itself and sets itself up around your role. Full details and troubleshooting: **[heydex.ai/install](https://heydex.ai/install/)**.
+Ask: **"Plan my day from my priorities and tasks. Tell me which sources you can read."**
 
-**If anything goes wrong:** nothing on your computer is changed half-way — copy the error message, paste it to your AI assistant, and it can tell you exactly what to do. Or follow the step-by-step path below instead.
+In the established setup, `/daily-plan` guides that workflow. Start with the notes you have; calendar, email and meeting services are optional connections. Dex should name missing sources rather than imply it checked them. Review the proposed plan and ask where it was saved.
 
----
+Next try **"Brief me on this person from my notes"** or **"Help me capture the follow-up from this meeting."** Available tools determine whether Dex can save the result. The released portable plugin alone provides read-only context, not the full task or meeting workflow.
 
-## Manual Setup (Step-by-Step Alternative)
+## How your app connects to Dex
+
+Dex's bridge connects an app to the selected vault, exposes the tools it can use, and translates supported app events. Installing a plugin does not create a vault, connect accounts, start background jobs or prove that every workflow works in that app.
+
+- **Automatic:** a configured and trusted app event runs the behavior.
+- **On demand:** you ask for a registered tool or skill.
+- **Guided:** Dex explains the steps that still need your participation.
+- **Unavailable:** the installed surface cannot deliver that behavior.
+
+These modes describe individual features, not whole apps. A package manifest or saved app selection is not proof of a successful session. See the [surface and capability guide](docs/HARNESS-PORTABILITY.md#capability-truth).
+
+## Privacy and control
+
+Your notes live in your vault. That does not mean all processing stays on your computer: your AI app may send the context it reads to its model provider, and optional integrations contact their services. Grant access to the folder and services you intend to use; a local plugin does not grant a web app access to your files.
+
+Dex's update service previews product changes and protects personal content through its ownership rules. Use [the update and recovery guide](docs/Dex_System/Updating_Dex.md). Review feedback before sending it under the configured consent policy; app permissions and diagnostic metadata do not establish who you are or authorize wider access.
+
+## Help, updates and leaving an app
+
+- Ask **"Check my Dex setup"** or run `/dex-doctor` in your established full-vault setup. The four-tool portable plugin does not include Doctor.
+- Ask **"Show me the Dex update preview"** or use `/dex-update` where the lifecycle service is available. Installing a plugin update and updating your vault are separate operations.
+- Use [the help guide](https://heydex.ai/help/) for setup, or [report a bug](https://github.com/davekilleen/dex/issues) without posting private vault contents. The [feedback guide](https://heydex.ai/help/feedback.html) explains reporting.
+- To stop using an app, close its Dex session and revoke its folder access or disable its plugin in that app. Keep the vault if you want your notes. Removing an app or plugin does not stop independently installed background jobs. New-app removal instructions remain pending native verification.
+
+## Guides
+
+- [System guide](docs/Dex_System/Dex_System_Guide.md): planning, meetings, people, tasks and reviews.
+- [Why the workflows exist](docs/Dex_System/Dex_Jobs_to_Be_Done.md).
+- [Background work](docs/Dex_System/Background_Processing_Guide.md), [memory ownership](docs/Dex_System/Memory_Ownership.md) and [Obsidian](docs/Dex_System/Obsidian_Guide.md).
+- [Technical guide](docs/Dex_System/Dex_Technical_Guide.md), [architecture map](docs/architecture/DEX-CORE-MAP.md) and [release history](CHANGELOG.md).
+
+## Claude Code primer
+
+This is the Claude Code route, including the desktop app's **Code** surface. Ordinary Claude Desktop chat has a separate read-only extension preview; it does not inherit Code hooks.
+
+Install Claude Code using [its official setup instructions](https://code.claude.com/docs/en/setup), sign in through the app, and open your Dex folder. From a terminal already in that folder:
+
+```bash
+claude
+```
+
+Use `/setup` for a new vault, `/daily-plan` for planning, and `/daily-review` to close the day. Existing users should keep their configured vault. Trusted Claude Code hooks supply session context and tool checks; disabled hooks, missing runtimes or permissions can prevent those behaviors. [Named sessions](docs/Dex_System/Named_Sessions_Guide.md) covers Claude-specific resume commands.
+
+<details>
+<summary>Manual Cursor setup and troubleshooting</summary>
+
+## Manual setup for Cursor
 
 Prefer to see every step, or the quick install hit a snag? This section does the same thing by hand.
 
 ### What You'll Need to Install (One-Time)
 
-1. **[Cursor](https://cursor.com/)** - Download and install (free account works fine)
-2. **[Git](https://git-scm.com)** - Required for setup and updates
+1. **[Cursor](https://cursor.com/)** - Download and install; check current account and usage requirements
+2. **[Git](https://git-scm.com)** - Required for this manual repository setup
    - **Mac:** Installs automatically when needed (you'll see a prompt)
    - **Windows:** Download from [git-scm.com/download/win](https://git-scm.com/download/win)
 3. **[Node.js](https://nodejs.org/)** - Download the "LTS" version and install (this enables the system's automation features)
@@ -106,7 +116,7 @@ Prefer to see every step, or the quick install hit a snag? This section does the
 
 All installers walk you through setup with default options.
 
-**Why Python 3.10+?** The MCP SDK (Model Context Protocol) requires Python 3.10 or newer. This powers the Work MCP server that enables task sync - when you check off a task in a meeting note, it updates everywhere automatically (person pages, project files, Tasks.md).
+**Why Python 3.10+?** The MCP SDK (Model Context Protocol) requires Python 3.10 or newer. This powers the Work MCP server that enables task sync - task updates through its tools can synchronize related pages. Manual checkbox edits need the separately configured sync service.
 
 **Mac users:** If this is your first time using command-line tools, macOS will prompt you to install "Command Line Developer Tools" during setup. Click **Install** when prompted - it's safe and required. Takes 2-3 minutes.
 
@@ -223,15 +233,15 @@ Then restart Cursor.
 
 If you use **Google Calendar**, you can have Dex show your real meetings when you run `/daily-plan` or ask "what's on my calendar today?" Two steps, one-time setup (Mac only):
 
-**Step 1 — Add Google to your Mac's Calendar app**  
+**Step 1 — Add Google to your Mac's Calendar app**
 Open the **Calendar** app (the one that came with your Mac). In the menu bar, click **Calendar** → **Add Account…** → choose **Google** → sign in with your Google account. Your Google events will sync into Calendar. Dex reads from this app, so once Google is here, Dex sees your meetings.
 
-**Step 2 — Let Cursor use your calendar**  
+**Step 2 — Let Cursor use your calendar**
 Open **System Settings** → **Privacy & Security** → **Calendars**. Turn **Cursor** on, then click **Cursor** and choose **Full** access (not "Add Only") so Dex can read your events. If macOS pops up asking "Cursor would like to access your calendars", click **Allow**.
 
 That's it. The installer already set up the rest on Mac. Your meetings—including recurring ones like weekly 1:1s—will show on the correct days in Dex.
 
-**More detail and troubleshooting:** [Calendar_Setup.md](06-Resources/Dex_System/Calendar_Setup.md) (in your vault after setup).  
+**More detail and troubleshooting:** [Calendar_Setup.md](docs/Dex_System/Calendar_Setup.md) (in your vault after setup).
 **On Windows?** Calendar connection is supported on Mac via Apple Calendar. We don't have Windows instructions in this repo yet.
 
 </details>
@@ -368,7 +378,7 @@ If `/daily-plan` doesn't show your meetings, or your recurring meetings (e.g. we
 2. **Let Cursor see your calendar** — **System Settings** → **Privacy & Security** → **Calendars** → turn **Cursor** on, then click **Cursor** and set access to **Full** (not "Add Only"). Restart Cursor after changing it.
 3. **If you skipped the installer or fixed Python yourself** — The installer normally sets up calendar support on Mac. If you didn't run it or installed packages by hand, in Terminal run: `.venv/bin/pip install -r core/mcp/requirements.txt`, then restart Cursor.
 
-See **[Calendar_Setup.md](06-Resources/Dex_System/Calendar_Setup.md)** for the full guide.
+See **[Calendar_Setup.md](docs/Dex_System/Calendar_Setup.md)** for the full guide.
 
 ---
 
@@ -382,15 +392,15 @@ And if the problem turns out to be a bug in Dex itself, you don't need a command
 
 ### Step 3: Tell Dex About Your Role
 
-In Cursor, look for a **chat panel** (usually on the right side of the screen). This is Claude - your AI assistant.
+In Cursor, look for a **chat panel** (usually on the right side of the screen). This is where you talk to your chosen AI assistant.
 
 **Here's exactly what to do:**
 
-1. **Click inside the chat panel** where it says "Message Claude..." or similar
+1. **Click inside the chat panel** where it says "Message..." or similar
 2. **Type exactly this:** `/setup`
 3. **Press Enter** - This invokes the setup skill
 4. **Wait ~30 seconds** - First time setup needs to load everything (you'll see "Thinking..." while it works)
-5. **Press Enter again** - Claude will now start asking questions
+5. **Press Enter again** - Dex will now start asking questions
 6. **Answer each question naturally:**
    - What's your role? (e.g., "CFO", "VP Sales", "Product Manager")
    - Company size?
@@ -398,550 +408,19 @@ In Cursor, look for a **chat panel** (usually on the right side of the screen). 
 
 Just type your answers like you're texting a colleague. Takes about 2 minutes total.
 
-**When it's done:** You'll see confirmation that your workspace is configured. All folders, commands, and automation are now tailored to your specific role.
+**When it's done:** You'll see confirmation that your workspace is configured. Your selected folders and workflows are tailored to your role. Check optional connections and jobs separately.
 
 ---
 
-## Three Ways to Access Claude
-
-You just used **Cursor** to run setup. That works great for daily use.
-
-There's also **Claude Code** - a more powerful option available via command line or Desktop app. Both give you **guaranteed hooks** (automatic behaviors that run deterministically, unlike CLAUDE.md which Claude might skip).
-
-| Access Method | What You Get | Hooks? | Setup |
-|--------------|--------------|--------|-------|
-| **Cursor** | Easy, already working | No | Already done |
-| **Claude Code** (command line) | Guaranteed hooks, persistent learning | Yes | 5 min install |
-| **Claude Code** (Desktop app) | Guaranteed hooks, persistent learning | Yes | 5 min install |
-
-**What are hooks?** Automatic behaviors triggered by events (session start, file read, etc.). They're deterministic - they ALWAYS run. Context loads guaranteed, learnings surface guaranteed, person details inject guaranteed.
-
-**Which to use?**
-- **Start with Cursor** - you're already set up
-- **Add Claude Code later** if you want guaranteed automation
-
-### What You Get With Each
-
-**Cursor:**
-- ✓ Full vault access
-- ✓ Multiple terminal windows for parallel work
-- ✓ Works immediately
-- ✗ No guaranteed hooks (context loading is probabilistic)
-
-**Claude Code (command line or Desktop):**
-- ✓ Everything Cursor does
-- ✓ PLUS guaranteed hooks for persistent learning and automatic context
-
-| Hook Example | What It Does |
-|--------------|--------------|
-| **Session start** | Loads Quarter Goals, Week Priorities, Strategic Pillars, Urgent Tasks automatically |
-| **Person context** | When Sarah is mentioned in a file, her person page context injects automatically |
-| **Company context** | When Acme Corp is referenced, company page details inject automatically |
-| **Mistake patterns** | Surfaces active patterns so Claude avoids repeating them |
-| **Learning reminders** | Prompts review when you have 5+ unreviewed learnings |
-
-**Command line vs Desktop:** Same core capabilities, different interfaces. Command line is text-based terminal. Desktop is a GUI with visual session management and side-by-side diffs.
-
-**Bottom line:** Cursor works great and is what most people use. Claude Code guarantees hooks run every time, making the system more intelligent and persistent. Many people use both - Cursor for heavy editing, Claude Code for workflows where reliability matters.
-
-[Full hooks documentation →](https://code.claude.com/docs/en/hooks)
-
----
-
-## Want Guaranteed Hooks? Use Claude Code (CLI or Desktop App)
-
-You're already set up with Cursor. If you want guaranteed hooks (automatic context loading every session), here are your two options:
-
-### Option 1: Claude Desktop App
-
-If you prefer visual interfaces over command line, use the Desktop app.
-
-**Requirements:**
-- Claude Pro ($20/month) or Max ($100-200/month, 5-20x higher usage limits) subscription - free Claude accounts don't have access to Claude Code
-
-**Setup (2 minutes):**
-
-1. Download from [claude.ai/download](https://claude.ai/download)
-2. Install and open the app
-3. Log in with your Claude Pro or Max account
-4. Click the **Code** tab (top left)
-5. Select your Dex folder to start a session
-
-**That's it.** Hooks run automatically - session start context loads, person details inject when mentioned, mistake patterns surface.
-
-**Desktop app benefits:**
-- **Visual interface** - See all sessions, review changes with side-by-side diffs
-- **Multiple parallel sessions** - Click "+ New session" to work on different tasks simultaneously
-- **Built-in integrations** - Connect Calendar, Slack, GitHub without manual configuration
-- **Same guaranteed hooks** as command line
-
----
-
-### Option 2: Command Line
-
-For those comfortable working in Terminal (Mac) or PowerShell (Windows), Claude Code runs from the command line.
-
-**Requirements:**
-- Claude Pro ($20/month) or Max ($100-200/month, 5-20x higher usage limits) subscription - free Claude accounts don't have access to Claude Code
-
-**Step 1: Install**
-
-You can install from your system's native terminal or from within Cursor (easiest since you're already there).
-
-**Option A: Native Terminal/PowerShell**
-
-**Mac - Terminal:**
-```bash
-curl -fsSL https://claude.ai/install.sh | bash
-```
-
-**Windows - PowerShell:**
-```powershell
-irm https://claude.ai/install.ps1 | iex
-```
-
-**Option B: From Inside Cursor (Easiest)**
-
-1. In Cursor, go to **View → Terminal** (opens a panel at the bottom)
-2. Copy and paste the command for your system:
-
-**Mac:**
-```bash
-curl -fsSL https://claude.ai/install.sh | bash
-```
-
-**Windows:**
-```powershell
-irm https://claude.ai/install.ps1 | iex
-```
-
-The installer automatically updates itself in the background to keep you current.
-
-**Step 2: Authenticate**
-
-In your terminal (native or Cursor's), run:
-
-```bash
-claude auth
-```
-
-This opens your browser. Log in with your Claude Pro or Max account.
-
-**Step 3: Start Claude Code**
-
-From your terminal, navigate to your Dex folder and run `claude`.
-
-**Note:** Folder name depends on how you got the code:
-- If you **cloned via Git**: folder is named `dex`
-- If you **downloaded ZIP**: folder is named `dex-main`
-
-**Mac:**
-```bash
-cd ~/Documents/dex        # or dex-main if you downloaded ZIP
-claude
-```
-
-**Windows:**
-```cmd
-cd %USERPROFILE%\Documents\dex        # or dex-main if you downloaded ZIP
-claude
-```
-
----
-
-**Need help?** See [official Claude Code setup docs](https://code.claude.com/docs/en/setup) for troubleshooting.
-
-**Which option?** Desktop app for visual interface. Command line for those comfortable in Terminal/PowerShell. Both give you the same guaranteed hooks capability.
-
----
-
-## Who This Is For
-
-Non-engineers. Product managers, marketers, sales leaders, designers, executives, HR leaders, consultants, coaches, analysts — anyone who wants the same leverage from AI that technical people have had access to.
-
-**You don't need to know how to code.** Just follow the setup above and talk to your AI assistant.
-
-**If you're an engineer:** Share this with your non-technical colleagues. Distribute Dex across your organization to accelerate AI fluency adoption.
-
-**Want to share this?** Point colleagues to the [companion blog post](https://www.linkedin.com/pulse/your-ai-chief-staff-building-personal-operating-system-dave-killeen-yxnqe/) for the full story. At the bottom of this README, there's a ready-to-use message you can copy and paste.
-
----
-
-## What It Actually Does
-
-Eight jobs that happen reliably every day:
-
-| Job | What It Solves |
-|-----|----------------|
-| **Start Each Day Focused** | One command gives you three priorities. Heavy meeting day? Drops to two. Won't let you overcommit. |
-| **Never Miss a Commitment** | Promises made in meetings extracted automatically. Three days old? Flagged. You can't forget. |
-| **Track Relationships** | Before any call: what you discussed last time, open items, what they care about. Never walk in cold. |
-| **Accelerate Career Growth** | Captures evidence automatically. Feedback from 1:1s, achievements, skills growth. Review-ready when you need it. |
-| **Manage Tasks Reliably** | Work MCP syncs tasks with unique IDs across all files. Check off once, updates everywhere. Deduplication prevents doubles. Priority limits stop overcommit. Strategic alignment required. |
-| **Reflect & Improve** | Captures mistakes → rules. Learns preferences. Each session makes the next better. |
-| **Keep Projects Moving** | Auto-detects stalls (12+ days no update). Surfaces blockers. You know what needs attention. |
-| **Evolve Itself** | System suggests improvements based on usage patterns. Monitors Claude Code releases daily - when new capabilities drop, explains what they mean for YOUR system and suggests implementations. Captures your improvement ideas too. AI ranks all by impact. `/dex-improve` plans implementation. System adapts to you. |
-
-**Want deeper context?** See [Dex_Jobs_to_Be_Done.md](06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md) for the full framework.
-
----
-
-## What's Included
-
-Out of the box, working immediately:
-
-- **8 core capabilities** - Daily focus, relationship tracking, commitment management, career evidence, task sync that actually works, learning system, project health monitoring, system evolution (see jobs table above)
-- **Complete planning system** - Quarterly goals → weekly priorities → daily plans, all connected with rollup tracking
-- **70+ ready-to-use skills** - `/daily-plan`, `/meeting-prep`, `/process-meetings`, `/week-review`, `/commitments`, `/relationship-radar` and more - invoke with `/skill-name`. Role-specific packs (career coaching, sales, finance…) switch on via `/manage-capabilities`.
-- **Role-based setup** - 31 roles from CEO to IC, scaffolds appropriate folder structure and workflows. Onboarding MCP enforces validation (email domain required for Internal/External person routing) with session resume capability
-- **Meeting intelligence** - Process transcripts into structured notes with action items auto-synced. Works with Granola MCP (included), or paste transcripts from any source - system recognizes and processes them
-- **Task management with unique IDs (Work MCP)** - Tasks sync everywhere automatically (meeting notes, person pages, project files). Check off once, updates everywhere. Deduplication prevents doubles. Priority limits stop overcommit.
-- **Career development coach** - Captures evidence automatically, prepares reviews, assesses promotion readiness
-- **Person & company pages** - Relationship context for individuals + organization-level rollups (contacts, meetings, tasks)
-- **Compound learning** - Captures preferences and mistakes. Every session makes the next one better.
-- **Self-upgrading system** - Checks for new Claude Code features daily. When detected, explains what they mean for YOUR system and suggests implementations. Like having a concierge who reads release notes you'll never read.
-- **Feature discovery** - `/dex-level-up` suggests capabilities you haven't tried yet based on your usage patterns
-
-## The Journey to Competitive Advantage
-
-**Week 1:** Use the scaffolded system. Value is immediate - commitments don't slip, meetings have context, day starts focused. System teaches you as you go.
-
-**Week 2:** Start extending. Tell Claude what you need, it builds it. Not coding - just describing. Add integrations, customize workflows, adapt to your exact role.
-
-**Month 1:** You're thinking like a builder. Understanding capabilities, spotting opportunities to automate, designing systems. AI fluency - the kind that compounds.
-
-**Why this matters:** Time saved → invested in learning → deeper fluency → more sophisticated builds → greater impact → career advantage. The gap is widening now. People building these systems in Q1 2026 will have a year's advantage by summer.
-
-**Total investment:** 30 minutes to set up. Two weeks to competence. The fluency compounds weekly.
-
----
-
-## Conversational Capture
-
-Ideas die between having them and recording them. Deciding where things belong kills momentum.
-
-Dex handles this through natural conversation. Just tell Claude things naturally:
-
-```
-You: "Sarah seemed worried about timeline but interested in Q2 pilot"
-
-Claude: "I see you have 'Sarah's team onboarding' and 'Q2 Planning' 
-in your Week Priorities. Should I add this to Sarah's person page 
-and the Q2 Planning project?"
-
-You: "Yes"
-```
-
-That's it. No special commands. No files to organize.
-
-**Strategic intelligence:**
-- Loads your Week Priorities and Quarterly Goals
-- Suggests routing based on what you're actually focused on
-- "Mobile app pricing" → sees "Mobile App Launch" in priorities → HIGH confidence
-- Person mentioned in priorities → routing gets confidence boost
-
-One decision instead of many. Immediate filing.
-
----
-
-## Career Development That Compounds
-
-Great work happens daily, but evidence disappears. Review time becomes a scramble to remember what you accomplished.
-
-Career coaching lives in Dex's optional **Career room** — Dex offers it during setup, or turn it on anytime with `/manage-capabilities`. Then run `/career-setup` once (job description, career ladder, recent review, growth goals). From that point forward, Dex can surface possible career evidence during supported workflows. It shows the exact sourced candidate and asks before saving anything:
-
-| When | What Dex May Suggest |
-|------|-------------------|
-| Daily reviews | Achievements that may be worth saving for promotion discussions |
-| Manager 1:1s (via Granola) | Feedback and development context found in the source note |
-| Project completions | Sourced impact and skills that may be useful later |
-| Weekly reviews | Work that may support a career skill |
-
-### Your Personal Career Coach
-
-Run `/career-coach` anytime for:
-
-| Mode | What It Does |
-|------|--------------|
-| **Weekly Report** | Generate professional update for your manager in 30 seconds |
-| **Monthly Reflection** | Spot patterns — what's working, where to focus |
-| **Self-Review** | Build annual review from accumulated evidence |
-| **Promotion Assessment** | Gap analysis with specific development plan |
-
-The coach adapts to your career level. Evidence compounds. The longer you use it, the more powerful it becomes.
-
-Your data stays on your laptop. It's yours.
-
----
-
-## Task Sync That Actually Works
-
-Tasks in multiple places (meeting notes, project files, person pages) don't sync in traditional systems. Check off one, others stay open.
-
-Dex handles this with the **Work MCP server** - a Python-based automation layer that syncs tasks with unique IDs across your entire vault. When you process a meeting, action items get IDs like `^task-20260128-001`. Tasks appear in both the meeting note and `03-Tasks/Tasks.md` with the same ID.
-
-Just tell Dex what you finished in natural language:
-- "I finished following up with John"
-- "Mark the proposal done"  
-- "Completed the API docs"
-
-The Work MCP finds the ID, updates everywhere automatically (Tasks.md, meeting notes, person pages, project pages), adds timestamp: `✅2026-01-28 14:35`.
-
-No manual syncing. No duplicates getting out of sync. One source of truth.
-
-**This is why Python installation is required** - the Work MCP server is the automation engine that makes task sync reliable and automatic.
-
----
-
-## How the Planning System Works
-
-Everything connects — from strategic pillars down to today's work:
-
-```mermaid
-%%{init: {'theme': 'neutral'}}%%
-flowchart TD
-    A[Strategic Pillars] --> B[Quarter Goals]
-    B --> C[Week Priorities]
-    C --> D[Daily Plan]
-    B -.-> E[Tasks.md]
-    A -.-> E
-    C -.-> E
-    E --> D
-    D --> F[Daily Review]
-    F -.Tomorrow.-> D
-    
-    style A fill:#e1f5e1
-    style B fill:#ffe1e1
-    style C fill:#e1e1ff
-    style D fill:#fff5e1
-```
-
-**Strategic Pillars** (your focus areas) → **Quarter Goals** (3-5 outcomes over 3 months) → **Week Priorities** (Top 3 this week) → **Daily Plan** (today's work) → **Tasks.md** (backlog tagged to goals).
-
-Work backwards from career impact: *What would make you incredibly happy you accomplished three months from now?* Quarterly goals become the north star connecting daily work to career-defining outcomes.
-
-See [Dex_System_Guide.md](06-Resources/Dex_System/Dex_System_Guide.md) for details.
-
----
-
-## Built-In Feature Discovery
-
-You're likely using 20% of the system's capabilities because you don't know what you don't know.
-
-Run `/dex-level-up` for progressive disclosure based on your actual usage. The system tracks which features you've used (stored locally in `System/usage_log.md`). When you run the command, it:
-
-1. Analyzes your usage patterns - what you're already doing consistently
-2. Identifies natural next steps - features that build on current habits
-3. Shows 2-3 specific suggestions - never overwhelming, always relevant
-4. Adapts to experience level - beginners get basics, power users get advanced features
-
-Week 1: suggests daily review workflows. Week 3: suggests custom MCP integrations.
-
-The system teaches you progressively. You learn what you need, when you need it.
-
----
-
-## The System That Improves Itself
-
-The system captures learnings and improves over time:
-
-- Run `/daily-review` - captures learnings to `System/Session_Learnings/`
-- Weekly synthesis (`/week-review`) - turns learnings into system improvements
-- Background automation - checks for new Claude Code features daily
-- Run `/dex-whats-new` - surfaces learnings and new capabilities you can use
-
-What gets captured:
-- Mistake patterns become rules that prevent repetition
-- Working preferences (communication style, meeting habits, tool choices)
-- System improvements - AI suggests implementations based on your usage
-
-Day 1: helpful but generic. Week 2: knows your preferences, catches common mistakes. Month 1: adapted to your specific work style.
-
-Each session makes the next one better.
-
----
-
-## Supported Roles
-
-31 role configurations. The scaffolding changes completely based on your answer.
-
-<details>
-<summary>View all roles</summary>
-
-**Core Functions:** Product Manager, Sales, Marketing, Engineering, Design
-
-**Customer-Facing:** Customer Success, Solutions Engineering
-
-**Operations:** Product Operations, RevOps/BizOps, Data/Analytics
-
-**Support Functions:** Finance, People (HR), Legal, IT Support
-
-**Leadership:** Founder
-
-**C-Suite:** CEO, CFO, COO, CMO, CRO, CTO, CPO, CIO, CISO, CHRO, CLO, CCO
-
-**Independent:** Fractional CPO, Consultant, Coach
-
-**Investment:** Venture Capital / Private Equity
 
 </details>
 
----
+## Contributing and credits
 
-## What It Costs
+[Contributions are welcome](CONTRIBUTING.md). An AI assistant can help prepare a change; review it and keep personal information out of the public repository.
 
-| Item | Cost |
-|------|------|
-| Cursor Free | $0 (limited usage, enough to try it) |
-| Cursor Pro | $20/month (Claude included) |
-| Claude Pro (for Claude Code) | $20/month — alternative to Cursor Pro |
-| Time | 10 minutes to set up |
-| Coding skills | None required |
-
----
-
-## Documentation
-
-**📖 Start with the [Dex Guide](https://heydex.ai/help/)** — a plain-English walkthrough from install to making Dex your own, with copy-paste prompts throughout. It's written for non-technical professionals and doubles as a hands-on education in Claude Code itself. (Also readable by AI agents: [llms.txt](https://heydex.ai/help/llms.txt).)
-
-Comprehensive guides included in the repo:
-
-- [Dex_System_Guide.md](06-Resources/Dex_System/Dex_System_Guide.md) - Complete feature reference and workflows
-- [Dex_Jobs_to_Be_Done.md](06-Resources/Dex_System/Dex_Jobs_to_Be_Done.md) - Why each piece exists and how they connect
-- [Dex_Technical_Guide.md](06-Resources/Dex_System/Dex_Technical_Guide.md) - Technical deep dive for those who want it
-- [Calendar_Setup.md](06-Resources/Dex_System/Calendar_Setup.md) - Connect Google Calendar to Dex (Mac)
-- [Folder_Structure.md](06-Resources/Dex_System/Folder_Structure.md) - PARA organization explained
-- [Updating_Dex.md](06-Resources/Dex_System/Updating_Dex.md) - How to safely update while preserving customizations
-
-Start with what you need. Go deeper if you're curious. No forced learning paths.
-
-These guides live in your vault after setup.
-
----
-
-## Updating Dex
-
-**Get updates with one command - no technical knowledge needed.**
-
-### Automatic Release Awareness
-
-At most once a day, Dex quietly checks whether a newer release exists and, if it can verify one, mentions it at the start of your session — with the exact version and a link so you can review before deciding. It never downloads or installs anything on its own, and if it can't verify a release it says nothing rather than guess.
-
-### Update in One Command
-
-```
-/dex-update
-```
-
-**That's it.** Dex shows you exactly what would change, you approve, and it handles the rest:
-- ✓ Previews every change before touching anything
-- ✓ Protects your data (your notes/tasks/projects are never part of an update)
-- ✓ If you've customized a file, nothing moves until you choose: keep yours, take the new one, or keep both
-- ✓ Backs up first, verifies after, and writes an undo receipt
-- ✓ `/dex-rollback` rewinds the exact change, byte for byte
-
-**Time:** 2-5 minutes  
-**Technical knowledge:** None
-
-### If Something Goes Wrong
-
-```
-/dex-rollback
-```
-
-Instantly restores the previous version.
-
-### Your Data Is Protected
-
-Updates never touch:
-- Your notes, tasks, projects, people pages
-- Your configuration (pillars, user profile)
-- Your customizations
-- Your API keys
-
-**For detailed instructions:** See [Updating_Dex.md](06-Resources/Dex_System/Updating_Dex.md)
-
----
-
-## Obsidian Integration (Optional)
-
-Dex works great with [Obsidian](https://obsidian.md) for visual graph navigation.
-
-**Why Obsidian?**
-- See your entire knowledge system as connected nodes
-- Click any reference to jump instantly between people, projects, meetings
-- Bidirectional task sync (check boxes in Obsidian → syncs everywhere)
-
-**Enable Obsidian mode:**
-
-```
-/dex-obsidian-setup
-```
-
-**What this does:**
-- Converts all references to clickable wiki links
-- Generates optimized Obsidian config (optional)
-- Enables bidirectional sync daemon (optional)
-
-**Time:** 1-2 minutes even for large vaults  
-**Safe:** Creates git backup before any changes
-
-**New to Obsidian?** Watch this [beginner's guide (5 min)](https://www.youtube.com/watch?v=gafuqdKwD_U).
-
-Obsidian is completely optional - Dex works perfectly in Cursor/terminal alone. Some users love the graph visualization for navigating their knowledge, others prefer the speed of terminal/Cursor. Both are first-class experiences.
-
-**Learn more:** See [Obsidian_Guide.md](06-Resources/Dex_System/Obsidian_Guide.md)
-
----
-
-## Resources
-
-- [Malleable Software: When Everyone Can Build, What Makes a Great Product?](https://www.youtube.com/watch?v=QcqBsxw9hQM) — Dave's keynote on the journey and thinking behind Dex
-- [Vibe PM Episode 8](https://youtu.be/WaqgSvL-V10?si=b2Pfwf7I5rozWCo0) — Video walkthrough
-- [Companion Blog Post](https://www.linkedin.com/pulse/your-ai-chief-staff-building-personal-operating-system-dave-killeen-yxnqe/) — Deep dive on all the concepts
-- [The highs and lows of building Dex](https://www.linkedin.com/feed/update/urn:li:activity:7486431643524796418/) — Dave's honest account: the pause, the unlock, and what shipped
-- [heydex.ai](https://heydex.ai) — the Dex site: [guide](https://heydex.ai/help/), [DexDiff profiles](https://heydex.ai), and [desktop/mobile beta signup](https://heydex.ai/beta)
-- [Cursor](https://cursor.com) — The AI-powered editor
-- [Granola](https://granola.ai) — Meeting transcription (optional)
-
----
-
-## Share the Vibes
-
-Found this useful? Share with colleagues:
-
-> I've been using an AI operating system for the past few weeks that completely changed how I think about AI tools. It's not just another chat interface — it's a personal chief of staff that manages my day-to-day work (meeting prep, task sync, relationship tracking, strategic planning).
->
-> Here's what surprised me: the system teaches you AI fluency as you use it. You start with pre-built workflows, but within two weeks you're extending it yourself — not coding, just describing what you need and watching it build. It's basically a hands-on course disguised as a productivity tool.
->
-> If you're thinking about where AI is going and how to build organizational muscle around it, this is the best learning environment I've found. Real stakes, real work, immediate feedback. Non-engineers set it up in 10 minutes.
->
-> Check out [Episode 8 of The Vibe PM Podcast](https://youtu.be/WaqgSvL-V10?si=b2Pfwf7I5rozWCo0) for the full walkthrough, or dive straight into the [GitHub repo](https://github.com/davekilleen/dex). Would love to hear what you build with it.
-
----
-
-## Credits
-
-Built with Claude. Created by [Dave Killeen](https://www.linkedin.com/in/davekilleen/), Field CPO for EMEA at Pendo and host of The Vibe PM Podcast.
-
-Thanks to [Noah Brier](https://github.com/heyitsnoah/claudesidian) for the Claudesidian repository that inspired me to bring AI into my markdown files with Obsidian last year and pulled me into this rewarding rabbit hole, and to [Aman Khan](https://www.linkedin.com/in/amanberkeley) from [Arize](https://arize.com) for opening my eyes to the power of MCP servers for task management, and more broadly, for making PKM systems more deterministic and less wishy-washy.
-
----
-
-## Contributing
-
-Made an improvement to your Dex setup? Fixed something that was bugging you? Built a skill that others could use? Dave would love to see it.
-
-**You don't need to be a developer.** Just tell Claude "I want to share my changes with the Dex community" and it'll walk you through the process. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
-
----
+Created by [Dave Killeen](https://www.linkedin.com/in/davekilleen/). Built with Claude; inspired by [Claudesidian](https://github.com/heyitsnoah/claudesidian). [The story behind Dex](https://www.youtube.com/watch?v=QcqBsxw9hQM) · [Video walkthrough](https://youtu.be/WaqgSvL-V10).
 
 ## License
 
-PolyForm Noncommercial 1.0.0.
-
-Commercial use is not allowed without a separate written commercial license from Dave Killeen. See `LICENSE` and `COMMERCIAL_LICENSE.md` for details.
-
----
-
-**Ready to start?** Follow the [quick install above](#quick-install-recommended) — one pasted line, then open the Dex folder in Cursor or Claude Code and say "hi".
+[PolyForm Noncommercial 1.0.0](LICENSE). Commercial use requires a separate written license; see [commercial licensing](COMMERCIAL_LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -200,12 +200,15 @@ python3 --version
 
 ### Step 2: Run the Installer
 
-Inside Cursor, you'll see a panel at the bottom (or go to **View → Terminal**). This is where you'll type commands.
+The repository installer is a **Bash script**. Run it from the Dex folder you opened in Step 1.
 
-Copy and paste this command and press Enter:
+- **Mac:** Open Cursor's **View → Terminal** in that folder.
+- **Windows:** Use **Git Bash**, supplied by Git for Windows, in that folder. Select the Git Bash terminal profile in Cursor, or open Git Bash separately and navigate to the folder. PowerShell can run the version checks above, but cannot directly run this Bash installer. For the PowerShell installation route, use [Quick install](#quick-install-claude-code-or-cursor).
+
+In the terminal selected above, run:
 
 ```bash
-./install.sh
+bash ./install.sh
 ```
 
 **What's happening:** This installs the automation that makes Dex work (task sync, career tracking, meeting intelligence). Takes 1-2 minutes. You'll see text scrolling - that's normal.
@@ -218,7 +221,7 @@ Copy and paste this command and press Enter:
 
 **Verify MCP servers:** Cursor should automatically detect `.mcp.json` and enable the MCP servers. Look for the MCP icon in Cursor's bottom panel - you should see server names with green checkmarks.
 
-**If you see errors:** The most common issue is Python dependencies not landing in Dex's virtual environment. Recreate it and reinstall — this keeps everything inside `.venv` and never touches your system Python:
+**If you see errors:** The most common issue is Python dependencies not landing in Dex's virtual environment. Use the commands for your operating system under [Python dependency troubleshooting](#all-platforms-could-not-install-python-dependencies). On **Mac**, those commands are:
 
 ```bash
 python3 -m venv .venv
@@ -283,7 +286,7 @@ This means Python wasn't added to your PATH during installation.
 4. ⚠️ **CHECK THE BOX: "Add Python to PATH"** (on first screen)
 5. Complete installation
 6. **Restart your terminal completely** (close and reopen)
-7. Run `./install.sh` again
+7. Return to **Git Bash** in your Dex folder and run `bash ./install.sh` again
 
 ---
 
@@ -296,7 +299,7 @@ Git for Windows isn't installed.
 1. Download from [git-scm.com/download/win](https://git-scm.com/download/win)
 2. Run installer with default options
 3. **Restart your terminal**
-4. Run `./install.sh` again
+4. Open **Git Bash** in your Dex folder and run `bash ./install.sh` again
 
 ---
 
@@ -304,7 +307,7 @@ Git for Windows isn't installed.
 
 The installer tries two methods automatically. If both fail, your pip version might be too old.
 
-**Fix (reinstall into Dex's virtual environment):**
+**Mac — reinstall into Dex's virtual environment:**
 
 ```bash
 python3 -m venv .venv
@@ -312,9 +315,9 @@ python3 -m venv .venv
 .venv/bin/pip install -r core/mcp/requirements.txt
 ```
 
-**Windows:**
+**Windows — PowerShell, in your Dex folder:**
 
-```bash
+```powershell
 python -m venv .venv
 .venv\Scripts\pip install --upgrade pip
 .venv\Scripts\pip install -r core/mcp/requirements.txt
@@ -328,7 +331,7 @@ If you see red error indicators next to MCP server names in Cursor:
 
 **"No server info found" error:**
 
-This means the Python MCP servers can't start. Most common fix — reinstall the dependencies into Dex's virtual environment:
+This means the Python MCP servers can't start. Reinstall dependencies using the [commands for your operating system](#all-platforms-could-not-install-python-dependencies). The **Mac** commands are:
 
 ```bash
 python3 -m venv .venv

--- a/core/tests/test_harness_golden_journeys.py
+++ b/core/tests/test_harness_golden_journeys.py
@@ -82,7 +82,16 @@ def test_each_harness_has_one_real_surface_and_one_explicit_boundary() -> None:
     assert "vault" in chatgpt_limits
     assert "person" in chatgpt_limits
     guide = (REPO_ROOT / "docs" / "HARNESS-PORTABILITY.md").read_text(encoding="utf-8")
-    assert "only leftover that still needs Dave is granting the Dex vault folder" in guide
+    chatgpt_journey = next(
+        line for line in guide.splitlines() if line.startswith("| ChatGPT Work desktop |")
+    )
+    assert "grant the Dex vault folder" in chatgpt_journey
+    assert "shared plugin cache on disk is not ChatGPT Work proof" in chatgpt_journey
+    assert (
+        "Folder access, installed runtime dependencies, workflows, permission refusals "
+        "and update/removal still need native proof."
+    ) in chatgpt_journey
+    assert "only leftover that still needs Dave is granting the Dex vault folder" not in guide
 
     claude = _rows("claude-code")
     assert claude["hooks"]["status"] == "native"
@@ -227,13 +236,25 @@ def test_developer_preview_guide_names_every_supported_profile_and_stop_line() -
         "BB",
     ):
         assert label in guide
-    assert "Unreleased build" in guide
-    assert "have not been merged, published" in guide
+    # Distribution is released; new-host acceptance remains a separate gate.
+    prose = " ".join(line.removeprefix("> ").strip() for line in guide.splitlines())
+    assert "Distribution baseline: v1.97.13" in prose
+    assert "Portable package files are present in the released vault bundle" in prose
+    assert "separate Claude Desktop and Gemini artifacts are also published" in prose
+    assert (
+        "Complete supported install, trust, workflow, update and removal journeys "
+        "in new apps remain **unverified**."
+    ) in prose
+    assert "unverified developer-preview recipes, not supported customer install instructions" in guide
+    assert "supported new-app install CTA remains withheld until native acceptance" in guide
+    assert "`dex-unreleased` are literal candidate identifiers" in guide
+    assert "Unreleased build" not in guide
+    assert "have not been merged, published" not in guide
     assert "Do not run an actual destructive command" in guide
-    assert "`codex/harness-portable-dex-resume`" in guide
     assert "**Branch:** `codex/harness-portable-dex-resume`" in plan
     assert "| macOS | Native CI required on each review head |" in guide
     assert "| Windows | Native CI required on each review head |" in guide
-    assert "Exact-commit native evidence belongs to the draft pull request" in guide
+    assert "Exact-commit CI evidence belongs to the pull request and release record" in guide
+    assert "CI protocol checks do not certify a complete user journey in the installed app" in guide
     assert "| macOS | Release-ready |" not in guide
     assert "| Windows | Release-ready |" not in guide

--- a/docs/Dex_System/Background_Processing_Guide.md
+++ b/docs/Dex_System/Background_Processing_Guide.md
@@ -1,40 +1,24 @@
 # Background Processing Guide
 
-Some skills take minutes, not seconds. Background processing lets you keep working while heavy operations run.
+Dex can do work during a conversation or through a separately installed job. The app you use determines whether a conversational workflow can continue in the background.
 
-## How It Works
+## Conversation work
 
-### Claude Code CLI
-Background agents run in a separate process. The skill acknowledges immediately and processes in the background. You get a notification when done.
+Claude Code supports background agents; use them only when the workflow and permissions permit it. In other apps, ask for progress in the current conversation unless background execution has been verified. A skill file does not create that execution capability.
 
-### Cursor
-Background execution works differently — skills provide progress updates during execution and break large batches into smaller chunks with intermediate output.
+The portable package distributed in v1.97.13 has read-only context tools and limited hook adapters. It does not install a meeting processor, task writer, session-end recorder or background service. Complete new-app journeys remain unverified; see [app capabilities](../../docs/HARNESS-PORTABILITY.md).
 
-## Candidate Skills
+## Scheduled work
 
-| Skill | Why Background | Typical Duration |
-|-------|---------------|-----------------|
-| `/process-meetings` | Heavy I/O, no interaction needed | 2-5 min for 5+ meetings |
-| `/review-article` | 22 parallel subagents | 3-8 min |
-| Intel pipelines (YouTube, Newsletter) | External API calls | 1-3 min each |
+Existing macOS jobs, such as meeting sync and optional Obsidian sync, run through the operating system after separate setup. They are independent of whether a chat is open. Installing or removing an app plugin does not start or stop those jobs. Check their configured schedule and health before expecting automatic results.
 
-## Design Pattern
+## What to expect
 
-All background-capable skills follow this pattern:
+- **Automatic:** a configured schedule or trusted app event runs the action. Identify which one.
+- **On demand:** request a workflow using its available skill and tools.
+- **Guided:** follow explicit steps where the app cannot complete the operation.
+- **Unavailable:** the current app or runtime cannot perform it; retain the existing working route.
 
-1. **Acknowledge** — Tell the user what's happening and how long to expect
-2. **Process** — Do the work silently
-3. **Summarize** — Report what was done with key metrics
+Syncing a meeting into the vault and processing its follow-ups are separate steps. A notification that meetings are waiting is not proof that tasks or person pages were updated. Ask for the saved result and check which sources were used.
 
-## When NOT to Use Background
-
-- Interactive skills that need user input mid-flow
-- Quick operations (<30 seconds)
-- Skills where the user needs to review output immediately
-
-## Implementation Notes
-
-- Skills declare background capability in their prompt
-- The harness (Claude Code / Cursor) decides execution model
-- Progress can be written to a status file for polling
-- Background skills should be idempotent — safe to re-run if interrupted
+See [the hook inventory](../../docs/architecture/HOOK-INVENTORY.md) for the exact separation between schedules, in-chat events and file writers.

--- a/docs/Dex_System/Calendar_Setup.md
+++ b/docs/Dex_System/Calendar_Setup.md
@@ -1,5 +1,7 @@
 # Connect Google Calendar to Dex (Mac)
 
+**Execution boundary:** this route uses macOS Calendar permissions in the app/runtime that actually runs Dex. A plugin or folder grant alone does not grant calendar access. The portable read-only package does not bundle the calendar integration; new-app calendar journeys need their own verification.
+
 This guide is for **Mac users** who use **Google Calendar** and want Dex to show their real meetings—including recurring ones like weekly 1:1s—when they run `/daily-plan` or ask "what's on my calendar today?"
 
 **Windows users:** Calendar connection is supported on Mac via Apple Calendar. This repo doesn't include Windows instructions yet.

--- a/docs/Dex_System/Dex_Jobs_to_Be_Done.md
+++ b/docs/Dex_System/Dex_Jobs_to_Be_Done.md
@@ -1,5 +1,7 @@
 # Dex: Jobs to Be Done
 
+Your vault holds the durable work; your chosen AI app helps you use it. The outcomes below describe the full Dex setup, not a guarantee that every app can perform every step. See [app and vault choice](../../README.md) and [capability modes](../../docs/HARNESS-PORTABILITY.md#capability-truth). New-app install and workflow support remains unverified even though portable package files are distributed in v1.97.13.
+
 **What this system actually does, and why each piece exists.**
 
 This document explains the purpose behind your Dex system. If you're new to the system, start here to understand what problems it solves. As you customize and extend Dex, this document evolves with you.
@@ -12,13 +14,13 @@ This document explains the purpose behind your Dex system. If you're new to the 
 
 A personal knowledge system that handles the cognitive overhead of professional life. Notes find their home. Tasks don't slip through cracks. People stay tracked. Your days start focused and end with reflection.
 
-The AI (Claude) acts as your knowledge assistant - helping you capture, organize, and act on information without drowning in process.
+Your chosen AI assistant acts as your knowledge assistant - helping you capture, organize, and act on information without drowning in process.
 
 ### What Makes It Different
 
 Traditional note systems are passive filing cabinets. Dex is active:
 
-- **AI-augmented**: Claude helps process, organize, and surface information
+- **AI-augmented**: Dex helps process, organize, and surface information
 - **Workflow-driven**: Commands guide you through daily and weekly rhythms
 - **Task-aware**: MCP server ensures tasks are validated, deduplicated, and prioritized
 - **Adaptable**: Pillars and structure customize to your role and priorities
@@ -43,13 +45,13 @@ Each job represents something that needs to happen reliably. The system exists t
 
 | Component | What It Does |
 |-----------|--------------|
-| Conversational capture | Just tell Claude things naturally - "Sarah worried about timeline but interested in Q2 pilot" |
+| Conversational capture | Tell Dex things naturally - "Sarah worried about timeline but interested in Q2 pilot" |
 | Strategic routing | Uses your Week Priorities and Quarterly Goals to suggest routing in real-time |
-| Immediate suggestions | Claude: "Should I add this to Sarah's person page and Q2 Planning project?" |
+| Immediate suggestions | Dex: "Should I add this to Sarah's person page and Q2 Planning project?" |
 | Work MCP for tasks | "Create task to finalize pricing" → validates, checks duplicates, writes to Tasks.md |
 | `/triage` for cleanup | Finds orphaned files and scattered tasks, routes strategically |
 
-**Example Flow**: You mention "Sarah seemed worried about timeline but interested in Q2 pilot". Claude immediately suggests: "I see you have 'Sarah's team onboarding' and 'Q2 Planning' in your Week Priorities. Should I add this to Sarah's person page and the Q2 Planning project?" You approve, it's filed. One decision, instant routing.
+**Example Flow**: You mention "Sarah seemed worried about timeline but interested in Q2 pilot". Dex suggests: "I see you have 'Sarah's team onboarding' and 'Q2 Planning' in your Week Priorities. Should I add this to Sarah's person page and the Q2 Planning project?" You approve, it's filed. One decision, instant routing.
 
 ---
 
@@ -83,7 +85,7 @@ Each job represents something that needs to happen reliably. The system exists t
 |-----------|--------------|
 | `People/` folder | One page per person with aggregated context |
 | `Companies/` folder | Organization-level aggregation of people, meetings, tasks |
-| Person lookup skill | Claude checks People folder first before any search |
+| Person lookup skill | Dex checks the People folder first before any search |
 | Meeting capture | Identifies people mentioned, updates their pages |
 | `/meeting-prep` command | Surfaces context about attendees before calls |
 | `refresh_company` tool | Pulls all related context into company page |
@@ -128,11 +130,11 @@ For organization-level context, check company pages in `05-Areas/Companies/`. Sh
 | `/journal` command | Morning, evening, or weekly reflection prompts |
 | `/review` command | End-of-day synthesis of what happened, captures learnings |
 | `/week` command | Weekly pattern recognition and planning |
-| Background changelog monitor | Checks every 6 hours for Claude updates, alerts you automatically |
+| Background changelog monitor | Installed macOS job checks every 6 hours for Claude Code updates; configured session hooks deliver the notice |
 | Learning review prompts | Daily check: when 5+ learnings pending, reminds you to review |
 | `Mistake_Patterns.md` | Logged mistakes become rules that prevent repetition |
 | `Working_Preferences.md` | Collaboration style captured and applied consistently |
-| Session learnings capture | Automatic logging in `System/Session_Learnings/` |
+| Session learnings capture | Logging in `System/Session_Learnings/` through configured Claude Code hooks; guided capture elsewhere |
 
 **v1.11.0**: Learning heartbeat now focused on operational knowledge only. Preferences are handled by Claude's built-in memory, so session learnings are cleaner and less noisy.
 
@@ -333,7 +335,7 @@ This document evolves as your Dex grows. When you:
 - Build automations, document what job they address
 - Discover workflow gaps, that might be a job waiting to be served
 
-The Documentation Sync behavior in CLAUDE.md ensures this stays current.
+Maintainers keep this guide aligned with shipped behavior; app instructions do not prove automatic documentation updates.
 
 ---
 

--- a/docs/Dex_System/Dex_Jobs_to_Be_Done.md
+++ b/docs/Dex_System/Dex_Jobs_to_Be_Done.md
@@ -129,7 +129,8 @@ For organization-level context, check company pages in `05-Areas/Companies/`. Sh
 |-----------|--------------|
 | `/journal` command | Morning, evening, or weekly reflection prompts |
 | `/review` command | End-of-day synthesis of what happened, captures learnings |
-| `/week` command | Weekly pattern recognition and planning |
+| `/week-review` command | Review accomplishments and patterns from the week |
+| `/week-plan` command | Set priorities for the week ahead |
 | Background changelog monitor | Installed macOS job checks every 6 hours for Claude Code updates; configured session hooks deliver the notice |
 | Learning review prompts | Daily check: when 5+ learnings pending, reminds you to review |
 | `Mistake_Patterns.md` | Logged mistakes become rules that prevent repetition |
@@ -138,7 +139,7 @@ For organization-level context, check company pages in `05-Areas/Companies/`. Sh
 
 **v1.11.0**: Learning heartbeat now focused on operational knowledge only. Preferences are handled by Claude's built-in memory, so session learnings are cleaner and less noisy.
 
-**Example Flow**: Friday afternoon, run `/week`. Dex synthesizes the week: themes that emerged, energy patterns (what energized vs drained you), progress by project, questions that came up. You spot a pattern - every meeting with Team X drains energy. That's useful data for next week's planning.
+**Example Flow**: Friday afternoon, run `/week-review`. Dex synthesizes the week: themes that emerged, energy patterns (what energized vs drained you), progress by project, questions that came up. You spot a pattern - every meeting with Team X drains energy. That's useful data for next week's planning with `/week-plan`.
 
 During the week, you mentioned "I prefer summaries in bullet points." Dex captured this in Session_Learnings and now asks: "You've mentioned this preference 3 times. Add to Working_Preferences.md so all future summaries use bullets?"
 

--- a/docs/Dex_System/Dex_System_Guide.md
+++ b/docs/Dex_System/Dex_System_Guide.md
@@ -1,5 +1,11 @@
 # Dex System Guide
 
+Dex is one personal system: your notes, priorities and saved work live in the vault; your AI app connects to it. Start with [choose your app and vault](../../README.md), then ask for one useful outcome: "Plan my day from my priorities and tasks; tell me which sources you can read."
+
+**Scope:** the complete workflows below describe the established full-vault setup, with Claude Code-specific automation named where used. Slash commands require the corresponding installed skill and tools. A portable skill file alone does not supply task writes, meeting follow-through, Doctor or updates. The v1.97.13 portable package is distributed; complete supported new-app journeys remain unverified. See [app capabilities](../../docs/HARNESS-PORTABILITY.md#capability-truth).
+
+Automatic means a configured, trusted event runs the behavior; on demand means you ask; guided means you complete explicit steps; unavailable means the surface cannot deliver it. Missing sources or services must be reported before claiming an outcome.
+
 **Personal Reference** — Full documentation for your Dex knowledge system.
 
 ---
@@ -8,7 +14,7 @@
 
 ```
 Morning    → Run /daily-plan for context-aware daily planning
-During day → Just tell Claude things - it routes them intelligently
+During day → Tell Dex things - it routes them intelligently
 After mtgs → Dex extracts action items and updates person pages
 As needed  → /triage finds orphaned files and scattered tasks
 End of day → Run /daily-review
@@ -29,13 +35,13 @@ End of week → Run /week-review
 
 **Conversational Capture:**
 
-Just tell Claude things naturally:
+Tell Dex things naturally:
 
 | What You Do | What Happens |
 |-------------|--------------|
-| "Sarah was worried about timeline but interested in Q2 pilot" | Claude suggests: "Add to Sarah's person page and Q2 Planning project?" |
+| "Sarah was worried about timeline but interested in Q2 pilot" | Dex suggests: "Add to Sarah's person page and Q2 Planning project?" |
 | "Create a task to finalize mobile app pricing" | Work MCP validates, checks duplicates, writes to Tasks.md |
-| "Random idea: could we automate weekly reports?" | Claude suggests where to file it based on your priorities |
+| "Random idea: could we automate weekly reports?" | Dex suggests where to file it based on your priorities |
 
 The system uses your Week Priorities and Quarterly Goals to route intelligently in real-time.
 
@@ -59,7 +65,7 @@ Creates reflection on:
 ### End of Week
 
 ```
-/week
+/week-review
 ```
 
 Creates weekly synthesis:
@@ -82,8 +88,8 @@ All skills are documented in detail in the **Skills System** section below. Here
 2. Optional: `/meeting-prep` — Prepare for first meeting
 
 **During Day:**
-- Tell Claude things naturally → it routes intelligently based on your priorities
-- "Sarah worried about timeline" → Claude suggests person page + project routing
+- Tell Dex things naturally → it routes intelligently based on your priorities
+- "Sarah worried about timeline" → Dex suggests person page + project routing
 - "Create task to finalize pricing" → Work MCP validates and adds to Tasks.md
 
 **End of Day:**
@@ -183,7 +189,7 @@ Triage is a cleanup tool that finds orphaned files and scattered tasks, then rou
 - Scattered `- [ ]` tasks across multiple notes
 - Periodic cleanup and routing
 
-**Note:** For most capture, just tell Claude things conversationally. Triage is for cleanup, not primary workflow.
+**Note:** For most capture, just tell Dex things conversationally. Triage is for cleanup, not primary workflow.
 
 ### How It Works
 
@@ -450,7 +456,7 @@ Dex checks if Anthropic has released new Claude Code features. When it finds som
 **Learning Review Prompts (daily at 5pm)**  
 As you work, Dex captures learnings in `System/Session_Learnings/`. When you accumulate 5+ learnings that haven't been reviewed yet, Dex reminds you: "📚 You have 7 pending learnings from this week. Worth reviewing?"
 
-Both happen automatically with no action from you. The system stays current on its own.
+These checks depend on the separately installed schedules and Claude Code notification hooks. A portable plugin installation starts neither; ask for a review where automatic delivery is unavailable.
 
 ### Learning Files
 
@@ -492,18 +498,18 @@ With automation, Dex nudges you at the right time. The system improves itself th
 
 **The Problem:** You're reading a meeting note that mentions "Sarah." Who is Sarah? What did you discuss last time? What's she working on?
 
-**What Dex Does:** Automatically loads relevant context in the background so you don't have to go hunting for it.
+**In configured Claude Code:** read hooks supply relevant context. Other surfaces can request person context on demand if that tool is registered; company injection is not part of the four-tool portable package.
 
 ### Smart Context Loading
 
 When you're reading any file that mentions people or companies, Dex quietly:
 - Looks up their person page or company page
 - Loads recent meeting history, action items, and relationship notes
-- Makes that information available to Claude in the background
+- Makes that information available to your assistant in the background
 
 This context comes from the real person and company pages in your vault. In Obsidian mode, names in meeting notes are linked to those pages using their actual paths, so a link always opens the page Dex found.
 
-You don't see any headers or popups - it just works. When you ask "What did Sarah and I discuss last week?", Claude already knows because it loaded her context automatically.
+You don't see any headers or popups - it just works. When you ask "What did Sarah and I discuss last week?", Dex can use the context supplied by the configured Claude Code hook.
 
 **Example:** You open a meeting note from a customer call. The note mentions "Acme Corp." Dex automatically loads the Acme Corp company page, sees you've had 5 meetings with them in the past month, notices there are 3 open action items, and uses that context to help you prepare better.
 
@@ -784,7 +790,7 @@ Skills are reusable AI workflows invoked with `/skill-name`. All skills follow t
 
 ### How Skills Work
 
-Skills define consistent behaviors Claude follows. When you type `/skill-name`, Claude reads the skill file at `.claude/skills/[skill-name]/SKILL.md` and follows its instructions.
+Skills define workflows for your assistant. Where slash commands are supported, your assistant loads the installed skill and follows its instructions. The canonical source is `.claude/skills/[skill-name]/SKILL.md`; generated copies serve other apps.
 
 ---
 
@@ -846,7 +852,7 @@ Meetings with attendees from these email domains will appear in Meeting History.
 
 ### How Skills Work
 
-Skills define consistent behaviors Claude follows. When a skill is relevant, Claude applies its protocol automatically.
+Skills define workflows for your assistant. Discovery and invocation depend on the app; confirm the skill and its required tools are available.
 
 ---
 
@@ -1170,7 +1176,7 @@ Complexity scales with your organization size (set during onboarding):
 
 ## Maintenance
 
-This guide stays current through the Documentation Sync behavior in CLAUDE.md. When significant system changes happen (new commands, behaviors, workflows), this guide updates automatically.
+Maintainers update this guide when shipped behavior changes and copy it byte-for-byte to the compatibility documentation tree. An instruction in CLAUDE.md is not evidence that documentation updated itself.
 
 **Rule of thumb**: If someone reading only this guide would miss something important about how to use the system, it needs updating.
 

--- a/docs/Dex_System/Dex_Technical_Guide.md
+++ b/docs/Dex_System/Dex_Technical_Guide.md
@@ -1,5 +1,9 @@
 # Dex Technical Guide
 
+**Scope, v1.97.13:** this guide describes the full Core/vault installation and retains Claude Code-specific examples. Portable package distribution is released; complete supported new-app journeys are unverified. The four-tool package does not include Work MCP mutation workflows, onboarding, Doctor, updates, feedback or session-end capture. [Exact surface limits](../../docs/HARNESS-PORTABILITY.md).
+
+Shared vault semantics, an app adapter and the model doing the reasoning are separate boundaries. An adapter translates selected-folder access, tool registration and verified events; it does not make every Core service available. Agent Skills syntax alone proves neither execution dependencies nor workflow results. OS jobs require separate installation; app hooks require their actual event, runtime and trust configuration.
+
 **Version:** 1.0  
 **Last Updated:** July 2026
 
@@ -21,7 +25,7 @@
 10. [Design Constraints](#design-constraints)
 
 **Related Guides:**
-- [Cursor Compatibility](Cursor_Compatibility.md) - Working with both Cursor and Claude Code
+- [App capability guide](../../docs/HARNESS-PORTABILITY.md) - Working with both Cursor and Claude Code
 
 ---
 
@@ -780,7 +784,7 @@ when it creates a task for you.
    - Person pages: Add meeting reference + action items
    - Career folder: If manager 1:1, save feedback to `05-Areas/Career/Evidence/`
 
-**User experience:** Meetings auto-sync. Dex notices waiting meetings at the start of a session — synced from Granola or captured by hand — and processes them in the background automatically. Nothing appears when there is nothing to do. You can still run `/process-meetings` directly whenever you want to review or triage meetings yourself.
+**User experience:** Configured meeting-sync jobs import meetings. The Claude Code session hook can announce waiting meetings; processing requires its skill, services and configured permissions. A queue notice is not proof of completed follow-ups. Run `/process-meetings` in the established full-vault setup to review or triage them. This workflow is not supplied by the portable read-only bridge.
 
 ### Why MCP for Integrations?
 
@@ -1193,7 +1197,7 @@ Understanding these constraints explains why Dex is designed the way it is.
 - `CLAUDE.md` - Main AI behavior instructions
 - `System/user-profile.yaml` - User preferences, company info, communication style
 - `System/pillars.yaml` - Strategic pillars (focus areas)
-- `.claude/settings.json` - Cursor settings (MCP server configs)
+- `.claude/settings.json` - Claude Code hook and permission settings
 
 ### Skills
 

--- a/docs/Dex_System/Distribution_Checklist.md
+++ b/docs/Dex_System/Distribution_Checklist.md
@@ -1,5 +1,17 @@
 # Dex Distribution Checklist
 
+## App support evidence (v1.97.13 baseline)
+
+Portable package files are distributed in v1.97.13. Distribution does not certify a host. Before adding a supported app CTA to GitHub or heydex.ai, retain exact version, artifact checksum, app/surface and OS evidence for:
+
+- New and existing/customized vault install, prerequisites and folder grants.
+- First useful plan, person/meeting context, task create/complete and meeting follow-through; missing optional integrations must be explicit.
+- Actual hook trust, denied permissions, conflicting roots, offline behavior and guided fallbacks.
+- Feedback preview/submission, update/rewind, disable/remove and preserved vault content.
+- Required CI and reviews, plus a real installed native app journey. A subprocess protocol test alone is insufficient.
+
+Keep GitHub and website install/help routes consistent. Verify the served artifact separately from local source. Complete new-app support evidence is pending; do not convert candidate registry modes into support badges.
+
 **Last Updated:** 2026-07-26 (v1.75.2)
 
 Maintainer reference for how Dex ships and what to check when cutting a release.
@@ -27,7 +39,7 @@ authoritative, CI-drift-gated list (names, tool counts, exact tools) is
 `docs/architecture/INVENTORY.md` § "MCP engines" — don't hand-copy it here.
 
 External MCPs (browser automation, user-installed integrations, hosted vendor
-MCPs) are not part of Dex; users add them via their own Claude settings.
+MCPs) are not part of Dex; users add them through their chosen app's supported integration settings.
 
 Optional companions degrade gracefully:
 - **Granola** — meeting sync uses Granola's official public API with

--- a/docs/Dex_System/Distribution_Strategy.md
+++ b/docs/Dex_System/Distribution_Strategy.md
@@ -1,5 +1,11 @@
 # Dex Distribution Strategy
 
+## Current distribution boundary
+
+The current route distributes the full vault/product bundle plus host-specific portable artifacts. Package files are present in v1.97.13; complete supported journeys for new apps remain unverified. Preserve established full-vault users while certifying each app's install, first outcome, permissions, update and removal separately. Use the [current checklist](Distribution_Checklist.md) and [app guide](../../docs/HARNESS-PORTABILITY.md) for that evidence.
+
+The January design record below is historical; its Git merge and customization mechanics are not current install instructions.
+
 **Status: HISTORICAL (January 2026) — mechanisms superseded.** The philosophy below
 ("Dex is yours, not ours"; updates enhance without disrupting) still holds, but the
 git-upstream merge mechanics this document describes were replaced in mid-2026 by

--- a/docs/Dex_System/Folder_Structure.md
+++ b/docs/Dex_System/Folder_Structure.md
@@ -1,5 +1,7 @@
 # Dex Folder Structure (PARA Method)
 
+The vault layout is shared across apps. Open the existing vault when changing apps; do not recreate it. Product instructions such as `CLAUDE.md` belong to a specific app surface, while your notes, people, tasks and priorities remain yours. Automatic filing and scheduled work below require their configured full-vault services; a portable plugin alone does not enable them.
+
 Dex uses the PARA method for organization: **Projects**, **Areas**, **Resources**, and **Archives**.
 
 ## What is PARA?
@@ -165,7 +167,7 @@ Archives = historical record, rarely consulted
 
 ### Auto-Archiving
 
-Plans and reviews automatically move here:
+Configured archive workflows move plans and reviews here:
 - Daily reviews → after `/daily-review` runs
 - Weekly plans → after `/week-plan` runs
 - Weekly reviews → after `/week-review` runs
@@ -234,7 +236,7 @@ System/
 
 Most users won't edit this directly—Dex manages it. But when you want to adjust strategic direction or preferences, the key files are here.
 
-**Background automation:** Dex also includes scripts in `.scripts/` that run automatically:
+**Background automation:** Dex includes scripts in `.scripts/` that run after their operating-system jobs have been separately installed and enabled:
 - `meeting-intel/sync-from-granola.cjs` — Syncs meetings, records attendee emails and locations, creates or suggests eligible people and companies, and verifies entity coverage. In Obsidian mode, names link to their actual person pages.
 - `check-anthropic-changelog.cjs` — Checks for Claude updates every 6 hours
 - `learning-review-prompt.sh` — Daily 5pm check for pending learnings

--- a/docs/Dex_System/Memory_Ownership.md
+++ b/docs/Dex_System/Memory_Ownership.md
@@ -1,27 +1,19 @@
 # Memory Ownership Boundaries
 
-## Claude Auto-Memory (native)
-**Owns:** Preferences, style, communication patterns, formatting choices
-**Examples:** "User prefers bullet points", "Use neutral mermaid theme", "Direct communication style"
-**How it works:** Automatically captured by Claude. Persists across all sessions and harnesses.
-**Dex action:** Don't duplicate. Don't capture preferences in learning-heartbeat.
+Your saved Dex work belongs to the vault. An AI app's native memory, conversation history and model context are separate stores; changing apps does not automatically transfer them.
 
-## Agent Memory (frontmatter, `memory: project`)
-**Owns:** Per-agent operational state across sessions
-**Examples:** "deal-attention flagged Acme Corp 3 times", "cracks-detector: pricing follow-up resolved"
-**How it works:** Each agent reads/writes its own memory. Scoped to that agent.
-**Dex action:** Configured in Phase 1, WP-1.1.
+## App-native memory
 
-## Dex Session Memory (learning-heartbeat)
-**Owns:** Operational decisions, commitments, work patterns, system learnings
-**Examples:** "Agreed to deliver DACH deck by Friday", "Meeting-prep skill needs more account context"
-**How it works:** Captured at session Stop, stored in System/Session_Learnings/
-**Dex action:** Filter for operational only (WP-2.1).
+Claude Code auto-memory may retain preferences and project knowledge when enabled in that host. Its scope and availability are host-owned. It does not persist across all AI apps by virtue of installing Dex. Keep preferences you want Dex to reuse in your vault profile or an explicitly saved note.
 
-## Dex Vault Search (QMD)
-**Owns:** Semantic search across all vault content
-**Dex action:** Unchanged.
+Agent-specific `memory: project` is also a host feature. A copied skill or agent instruction does not establish equivalent memory elsewhere.
 
-## Dex Proactive Intelligence (Phase 4 — planned)
-**Owns:** Anticipation, pre-fetching, pattern prediction across agents
-**Dex action:** Future. Enhanced by agent memory providing richer signal.
+## Dex session learnings
+
+Operational decisions, commitments and reusable lessons can be saved in `System/Session_Learnings/` by the configured full-vault workflows. Claude Code has session-related capture hooks; the v1.97.13 portable package does not include a session-end capture adapter. In a new app, ask for a summary and confirm whether saving is available. Do not claim a memory was stored until the saved result is read back.
+
+## Search and context
+
+Vault search indexes existing content when its search service is configured. The portable `boot_today` and `get_person_context` tools read selected vault files; they do not record the current conversation. A missing index, ungranted folder or unavailable tool must be reported as such.
+
+Vault files are local, but an AI app may send the context it reads to its model provider. Folder access, connected-service permissions and feedback consent remain separate decisions. See [app limits](../../docs/HARNESS-PORTABILITY.md) and [the system guide](Dex_System_Guide.md).

--- a/docs/Dex_System/Named_Sessions_Guide.md
+++ b/docs/Dex_System/Named_Sessions_Guide.md
@@ -1,5 +1,7 @@
 # Named Sessions
 
+**Claude Code-specific.** The `/rename` and `claude --resume` examples below use Claude Code's conversation store. They are not portable Dex commands. In another app, use that app's conversation controls; only work explicitly saved in the vault is shared. New-app session continuity remains unverified.
+
 Pick up exactly where you left off. Named sessions keep full conversation history so you never re-explain context.
 
 ---

--- a/docs/Dex_System/Obsidian_Guide.md
+++ b/docs/Dex_System/Obsidian_Guide.md
@@ -1,5 +1,7 @@
 # Using Dex with Obsidian
 
+Obsidian reads the same local vault independently of your AI app. Wiki-link migration and cross-file task sync are separate Dex services: they require setup and are not enabled merely by opening the folder or installing a portable plugin. See [app limits](../../docs/HARNESS-PORTABILITY.md).
+
 Obsidian is a free markdown editor with powerful graph visualization. It's completely optional, but many users love seeing their knowledge as a connected graph.
 
 **New to Obsidian?** Watch this [beginner's guide (5 min)](https://www.youtube.com/watch?v=gafuqdKwD_U) to see what it can do.
@@ -23,7 +25,7 @@ Obsidian is a free markdown editor with powerful graph visualization. It's compl
 
 1. Download Obsidian (free): https://obsidian.md
 2. Open your Dex vault: File → Open Folder → Select your Dex directory
-3. Enable Obsidian mode: Run `/dex-obsidian-setup` in Cursor/Claude
+3. Enable Obsidian mode: Run `/dex-obsidian-setup` in your established Cursor or Claude Code setup
 
 ## Obsidian vs Terminal/Cursor
 
@@ -37,7 +39,7 @@ Both are first-class experiences:
 | AI integration | ❌ Limited | ✅ Native |
 | Speed | ⚡ Fast | ⚡⚡ Faster |
 
-**Recommendation:** Use both! Obsidian for visual navigation and reading, Cursor/Claude for AI-powered workflows.
+**Recommendation:** Use both! Obsidian for visual navigation and reading, your configured AI app for Dex workflows.
 
 ## Setting Up Later
 

--- a/docs/Dex_System/README.md
+++ b/docs/Dex_System/README.md
@@ -1,4 +1,12 @@
-# Dex system documentation bridge
+# Dex system guides
+
+Start with the [system guide](Dex_System_Guide.md) for planning, meetings, people and tasks, or [jobs to be done](Dex_Jobs_to_Be_Done.md) for why those workflows exist. Dex is your durable personal system; the AI app is how you work with it.
+
+For app choice, new or existing vault setup and the first useful result, use the [repository entry guide](../../README.md). Claude Code and Cursor retain their established full-vault routes. Portable files are distributed in v1.97.13; complete new-app journeys remain unverified. [Exact app limits](../../docs/HARNESS-PORTABILITY.md).
+
+[Updating and recovery](Updating_Dex.md) · [Background processing](Background_Processing_Guide.md) · [Memory ownership](Memory_Ownership.md) · [Obsidian](Obsidian_Guide.md).
+
+## Documentation ownership
 
 `docs/Dex_System/` is the Brain-owned home for Dex's shipped system guides.
 

--- a/docs/Dex_System/Updating_Dex.md
+++ b/docs/Dex_System/Updating_Dex.md
@@ -1,5 +1,17 @@
 # Updating Dex — Explained Simply
 
+## Choose the update route for your installed setup
+
+Dex product files, your personal vault and the AI app's plugin have separate lifecycles. In an established full-vault setup, use `/dex-update` (or ask for the update preview) with the configured Dex lifecycle service. Start from the same vault you already use; do not create another vault to update or switch apps.
+
+The v1.97.13 portable package exposes four read-only/advisory tools; it does not bundle the installer, updater, Doctor or rollback service. A generated update skill does not supply those dependencies. Complete new-app update and removal journeys remain unverified. Use your existing working app for vault updates until [the app-specific route](../../docs/HARNESS-PORTABILITY.md) has native proof.
+
+Automatic release notices depend on configured Claude Code session hooks. Elsewhere, ask to check the release explicitly if that service is available. A notice is never approval to install.
+
+To leave an app, close its Dex session and disable its plugin or revoke its folder grant. Keep your vault to retain your notes. Independently installed jobs and connected accounts need separate controls; removing a plugin does not disable them. No new-app removal command is certified by this guide.
+
+The receipt-backed flow below applies when the full lifecycle service is available. Rewind requires an eligible receipt and successful safety checks; it is not an unconditional undo of every file or app change.
+
 **Last Updated:** July 26, 2026 (reflects the receipt-backed update system, v1.65+)
 
 This guide explains how Dex updates work, written for people who've never used

--- a/docs/HARNESS-PORTABILITY.md
+++ b/docs/HARNESS-PORTABILITY.md
@@ -1,12 +1,16 @@
 # Use Dex from another agent harness
 
-> **Unreleased build.** These packages are implemented and locally verified on
-> `codex/harness-portable-dex-resume`. They have not been merged, published, submitted
-> to a marketplace, or released to users.
+> **Distribution baseline: v1.97.13 (7 September 2026).** Portable package files
+> are present in the released vault bundle; separate Claude Desktop and Gemini
+> artifacts are also published. Complete supported install, trust, workflow,
+> update and removal journeys in new apps remain **unverified**. Package
+> publication, conformance tests and saved profile receipts are distinct evidence.
+> [Release](https://github.com/davekilleen/dex/releases/tag/v1.97.13).
 
 Dex is the durable vault and capability layer; the harness is the application
-or agent you use to talk to it. Start every host from the **full Dex folder** so
-the root instructions and vault are in scope. Onboarding detects likely hosts,
+or agent you use to talk to it. For a local developer preview, explicitly select the **existing full Dex folder**
+and confirm the actual host has permission to read it. Installing a plugin does
+not create a vault or grant access. Onboarding detects likely hosts,
 lets the user select more than one, previews the exact capability modes, and
 stores the confirmed selection at `System/.dex/harness-profile.json`. Doctor
 reports the same receipt.
@@ -19,8 +23,8 @@ reports the same receipt.
 | Windows | Native CI required on each review head | The same native runtime round trips must pass with a Windows Python executable path before this platform can be called release-ready. |
 | Linux | Deferred | The runtime is still exercised on the Devbox, but Linux packaging and live-host verification are explicitly outside this release. |
 
-Exact-commit native evidence belongs to the draft pull request checks and release
-record, rather than becoming a timeless pass claim in this versioned guide.
+Exact-commit CI evidence belongs to the pull request and release record. Native
+CI protocol checks do not certify a complete user journey in the installed app.
 
 The portable Agent Plugin package requires Node 20+ and Python 3.11+. The Claude
 Desktop MCPB is the documented exception: it declares Node.js >=18, supplied by
@@ -50,7 +54,7 @@ trusted PreToolUse hook intercepts the action before it runs.
 
 ## Local installation journeys
 
-These are developer-preview journeys, not customer release instructions.
+These are unverified developer-preview recipes, not supported customer install instructions. Local marketplace names such as `dex-unreleased` are literal candidate identifiers retained in the generated metadata; they do not mean the v1.97.13 files were never distributed. Do not run preview setup over a working vault without reviewing its scope. The supported new-app install CTA remains withheld until native acceptance.
 
 Build the separate installable artifacts from the same canonical package:
 
@@ -71,16 +75,16 @@ and the final publication step succeeds.
 | Harness | Local package journey | Honest boundary |
 | --- | --- | --- |
 | Codex CLI / desktop | From the Dex root, run `codex plugin marketplace add .`, then `codex plugin add dex@dex-unreleased`. Review and trust the hooks, then start a new task. | Codex IDE extensions do not load plugins. |
-| ChatGPT Work desktop | Copy `packages/dex-agent-plugin` to `~/.codex/plugins/dex`, add `~/.agents/plugins/marketplace.json` with `source.path` `./.codex/plugins/dex` (relative to the home marketplace root, not the `.agents/plugins` folder), restart the ChatGPT desktop app, install Dex from **Dex (unreleased local build)**, review its hooks, start a new Work chat with Work locally selected, and grant the Dex vault folder. If Work is already opened on this Dex checkout, the repo marketplace at `.agents/plugins/marketplace.json` can be used instead of the personal copy. | ChatGPT web cannot use this local plugin for a local vault. A person must complete this on a real desktop; Ubuntu Cloud is not that journey. A shared plugin cache on disk is not ChatGPT Work proof. The only leftover that still needs Dave is granting the Dex vault folder on a real desktop. This runner will not invent that grant. |
+| ChatGPT Work desktop | Copy `packages/dex-agent-plugin` to `~/.codex/plugins/dex`, add `~/.agents/plugins/marketplace.json` with `source.path` `./.codex/plugins/dex` (relative to the home marketplace root, not the `.agents/plugins` folder), restart the ChatGPT desktop app, install Dex from **Dex (unreleased local build)**, review its hooks, start a new Work chat with Work locally selected, and grant the Dex vault folder. If Work is already opened on this Dex checkout, the repo marketplace at `.agents/plugins/marketplace.json` can be used instead of the personal copy. | ChatGPT web cannot use this local plugin for a local vault. A person must complete this on a real desktop; Ubuntu Cloud is not that journey. A shared plugin cache on disk is not ChatGPT Work proof. Folder access, installed runtime dependencies, workflows, permission refusals and update/removal still need native proof. |
 | Claude Code | Run `claude plugin validate packages/dex-agent-plugin`, then test with `claude --plugin-dir ./packages/dex-agent-plugin` before creating a private marketplace entry. | The shared package maps two lifecycle guarantees; Claude's complete mature Dex hook suite remains the reference. |
 | Claude Desktop | Select `build/portable-artifacts/dex-claude-desktop.mcpb` in **Settings > Extensions > Advanced settings > Install Extension**, then select the Dex vault during configuration. | The officially validated desktop bundle exposes local read-only MCP tools. Chat does not run hooks, and Python 3.11+ remains required. |
 | Claude Cowork | Upload/install the reviewed Claude plugin package and grant the full Dex folder. | Cowork external connectors require a public internet endpoint, so the local stdio MCP server is not claimed. |
 | GitHub Copilot CLI | From the Dex checkout, run `copilot plugin install ./packages/dex-agent-plugin`. Confirm Dex in `copilot plugin list`. Start the CLI from the Dex folder so the vault is the working directory. | Skills and MCP use the open package. Hooks are not bundled. A person must do this in a real terminal; Ubuntu Cloud is not that journey. Detection tests and CI are not a live install. |
-| Cursor | Copy or link `packages/dex-agent-plugin` to `~/.cursor/plugins/local/dex`, reload Cursor, and approve the native hooks. | Local sessions get context and safety hooks. Cursor cloud agents do not run `sessionStart`, so that lifecycle guarantee is local-only. |
+| Cursor | Copy or link `packages/dex-agent-plugin` to `~/.cursor/plugins/local/dex`, reload Cursor, and approve the native hooks. | The candidate declares local context and safety hooks; native behavior remains unverified. Cursor cloud agents do not run `sessionStart`, so that lifecycle guarantee is local-only. |
 | Gemini CLI | Run `gemini extensions install build/portable-artifacts/dex-gemini-extension`, approve its hooks, and restart Gemini CLI in the full Dex folder. | Gemini's fixed hook file uses a different schema, so Dex builds a separate complete artifact from the same canonical sources. |
 | Agent Plugins v1 client | Install the folder using root `plugin.json` and `mcp.json`. | The open specification standardizes skills and MCP, not every host lifecycle. |
 | Pi | Use the native `dex-pi/extensions/dex` package from the pinned [`dex-pi` commit `5bf33ad7b23a06a890b25445cb1b4f4077b2ac19`](https://github.com/davekilleen/dex-pi/tree/5bf33ad7b23a06a890b25445cb1b4f4077b2ac19) and open the full Dex folder. | Pi has no built-in MCP client; its extension supplies native tools and lifecycle events instead. Core verifies the pinned manifest and source-level lifecycle markers when the checkout is available; live installation remains a release-candidate check. |
-| BB | Install the separately built `bb-plugin-dex` package from a reviewed local path and select the vault in settings. | Version one is macOS-only and read-only: status, capabilities, brief, CLI, and panel; no jobs, writes, provider bridge, or marketplace release. BB's Windows route uses WSL2 and stays in the deferred Linux lane. |
+| BB | Candidate work paused; no install recommendation. | Separate unreleased read-only package; no supported host or marketplace claim. |
 
 ## Acceptance journey
 
@@ -100,6 +104,26 @@ Do not run an actual destructive command to test a hook. The package's hook and
 MCP test harnesses submit the proposal as data only.
 
 ## Capability truth
+
+Modes must be read per surface and per operation. `automatic` requires a trusted
+host event; `on_demand` requires a registered tool; `guided` needs explicit user
+steps; `unavailable` has no implemented route. A declared candidate mode is not
+native proof. The released bridge exposes four read-only/advisory tools only.
+
+| Surface | Candidate mode and scope | Evidence boundary |
+| --- | --- | --- |
+| Claude Code full-vault setup | Automatic configured session/tool hooks; on-demand full skills/services | Existing reference route; plugin subset is not the entire hook suite. |
+| Cursor full-vault setup | On-demand configured tools/skills | Existing route; portable local-hook candidate requires separate proof. |
+| Codex CLI and desktop | Candidate automatic boot/gate hooks; on-demand four-tool bridge; guided finish | Native complete journey unverified; task writes, feedback, Doctor and updater absent from this bundle. |
+| ChatGPT Work desktop | Candidate on-demand bridge after local execution and folder grant | Native installation, tools and workflows unverified. |
+| Claude Desktop chat | Candidate on-demand four-tool MCPB; automatic hooks unavailable | Artifact validation is not an installed desktop journey. |
+| Claude Cowork | Candidate skill/plugin route; local tool/runtime scope unverified | External connectors cannot reach the local stdio server as packaged. |
+| Copilot CLI | Candidate on-demand skills/MCP; hooks unavailable in this package | Complete native journey unverified; no VS Code/app support inferred. |
+| Gemini CLI | Candidate automatic SessionStart/BeforeTool; on-demand read tools | Separate artifact; native complete journey unverified. |
+| Agent Plugins v1 clients | Candidate on-demand skills/MCP | Each concrete client needs proof; no universal lifecycle guarantee. |
+| Pi | Candidate native extension tools/events | Separate unreleased extension; native install remains unverified. |
+| BB | Unavailable as a supported route; candidate paused | No install or activation recommendation. |
+| Codex IDE extension, ChatGPT web | This local plugin route unavailable | No local-vault bridge or complete journey claimed. |
 
 The current matrix is generated from `core/harnesses/registry.json`, not this
 prose. Each row is explicitly `automatic`, `on_demand`, `guided`, or

--- a/docs/architecture/DEX-CORE-MAP.md
+++ b/docs/architecture/DEX-CORE-MAP.md
@@ -4,7 +4,7 @@
 >
 > **Status vocabulary.** `SHIPPED` = in a released version tag. `LOCAL` = merged on `main`, not yet in a release tag. `PROTOTYPE` = built, not verified against live/real use. `PLANNED` = designed, not built.
 >
-> **Ground truth as of** `upstream/main` at `fd335640`, latest release tag **v1.97.0** (2026-08-13). Dex Everywhere portability remains unreleased on this branch; exact-head native macOS/Windows acceptance is green, while the mandatory Fable reviews and live release-candidate installs are still pending.
+> **Portability release truth, 7 September 2026:** current release **v1.97.13**, baseline `a7f3c782`. Portable package distribution is released. Complete native new-app install, workflow, update and removal acceptance remains unverified; protocol CI is not host support. See [the maintained surface guide](../HARNESS-PORTABILITY.md). Subsystem history below retains its own dated evidence.
 >
 > **Don't duplicate generated files.** Tool lists, skill lists, ownership-class path tables, and MCP↔skill wiring live in the auto-generated `docs/architecture/INVENTORY.md`. This map cross-references it; it does not restate it.
 >

--- a/docs/architecture/HARNESS-CAPABILITY.md
+++ b/docs/architecture/HARNESS-CAPABILITY.md
@@ -1,5 +1,9 @@
 # Harness capability contract
 
+**Release evidence:** v1.97.13 distributes the package, but complete new-host support remains unverified. Registry modes describe implementation intent; profile selection records configuration history. Neither proves the active host, loaded version, tool availability or successful journey. See [per-surface modes and limits](../HARNESS-PORTABILITY.md#capability-truth).
+
+The portable read-only bridge bundles only four tools. Registering or copying a skill does not provide Work MCP, lifecycle mutation operations, Doctor, feedback, update services or OS schedules. Each declared automatic mode needs a real trusted event in the named app and surface.
+
 Dex is a vault plus a set of tools. The assistant that sits in front of it
 (Claude Code, Cursor, Codex, Gemini CLI, or something else) is a **harness**.
 Which language model that harness uses is a separate question. This document
@@ -8,21 +12,21 @@ does not revive `/ai-setup`.
 
 | Axis | What it is | Cost |
 | --- | --- | --- |
-| **Harness agnosticism** | Packaging: skills, hooks, MCP config | Mostly a packaging problem |
+| **Harness agnosticism** | Shared services plus app-specific skills, events, permissions and tool registration | Requires complete dependencies and native workflow evidence |
 | **Model agnosticism** | Which LLM does the reasoning | Quality / instruction adherence. Not solved by a config flag. |
 
 Claude Code remains the **Tier 3 reference implementation** for Dex's complete,
 mature hook / injector / self-learning surface. The portable plugin now gives
-other hook-capable hosts a tested subset of automatic behavior from the same
-source modules. That is not a promise that every host has every Claude hook.
+other hook-capable hosts candidate adapters using the same source modules.
+Package/conformance tests do not prove automatic behavior in an installed host. That is not a promise that every host has every Claude hook.
 
 ## Capability tiers
 
 | Tier | Name | What it is | Who can run it |
 | --- | --- | --- | --- |
 | **Tier 0 Vault** | Markdown + PARA | Notes, people, projects, tasks as files. No agent required. | Any editor |
-| **Tier 1 Core** | MCP + scheduled jobs | Tasks, people index, meeting sync, search. Background jobs already run on a schedule. | Any MCP-capable harness |
-| **Tier 2 Skills** | Agent Skills + journeys | Named `/commands` generated into `.agents/skills/` from canonical `.claude/skills/`. | Any harness that reads Agent Skills / `AGENTS.md` |
+| **Tier 1 Core** | MCP + scheduled jobs | Tasks, people index, meeting sync, search. Background jobs already run on a schedule. | An app with the relevant Core services installed and registered |
+| **Tier 2 Skills** | Agent Skills + journeys | Named `/commands` generated into `.agents/skills/` from canonical `.claude/skills/`. | An app that reads the skill and supplies its execution dependencies |
 | **Tier 3 Full** | Hooks, injectors, self-learning | Session context, inject-on-read, pre-tool-use gates, mid-session health, session-end snapshot. | Claude Code is the complete reference; other native adapters expose named subsets only |
 
 Layers 1–2 of the repo (`core/`, MCP servers, `.scripts/`, including
@@ -129,7 +133,7 @@ The three-bucket inventory (scheduled / in-turn inject / gates), including
 session-end writers left out of those buckets, is in
 [`HOOK-INVENTORY.md`](./HOOK-INVENTORY.md).
 
-### Portable native slice: shared payloads, tools, and verified hooks
+### Portable native slice: shared payloads, tools, and candidate hooks
 
 Two in-turn context payloads now live in `core/context/`, and the destructive
 command/path decision lives in `core/gates/`. They are exposed as Work MCP
@@ -150,11 +154,11 @@ PreToolUse hook wiring. Codex and Claude hooks require user trust before they
 run. An MCP result alone is still not an interceptor: a host must verify that
 it invokes the check before the action and honours `refused=true`.
 
-OpenAI's package works in Codex CLI/desktop and supported ChatGPT surfaces, but
-not the Codex IDE extension. ChatGPT web and Cowork external connectors cannot
+The package declares Codex CLI/desktop and candidate local ChatGPT surfaces;
+complete native journeys are unverified. The Codex IDE extension is not a claimed route. ChatGPT web and Cowork external connectors cannot
 reach this local stdio server without a separately secured public endpoint.
 Pi uses its native Dex extension rather than pretending to be an MCP client.
-BB uses the separate read-only `bb-plugin-dex` package.
+BB has a separate read-only candidate package; its work is paused and no install is recommended.
 
 ### What this change does not do
 

--- a/docs/architecture/HOOK-INVENTORY.md
+++ b/docs/architecture/HOOK-INVENTORY.md
@@ -1,5 +1,7 @@
 # Hook inventory (three buckets)
 
+**v1.97.13 evidence boundary:** portable files are released; a mapped event or passing protocol test is not proof that an installed app intercepts it. Complete native new-app journeys remain unverified. Keep each existing hook disposition below; session-end capture, other injectors and writers are not silently included in the portable subset. See [surface modes](../HARNESS-PORTABILITY.md#capability-truth).
+
 This is the #506 follow-up inventory. It classifies every file under
 `.claude/hooks/` so the next slices know what to move, what to wrap, and
 what to leave. **Do not mass-migrate hooks.**
@@ -65,7 +67,7 @@ this bucket is silently treated as portable.
 ## 3. Gates
 
 These block or redirect a call **before** it runs. The shared destructive-action
-gate is mapped to verified PreToolUse events in the Codex/Claude plugin; every
+gate is mapped to candidate PreToolUse adapters in the Codex/Claude plugin; every
 other gate still needs a host-specific equivalent before Dex can claim it.
 
 | File | Event | Why it is a gate |

--- a/packages/dex-agent-plugin/README.md
+++ b/packages/dex-agent-plugin/README.md
@@ -1,6 +1,8 @@
 # Dex portable agent plugin
 
-One unreleased package carries Dex's generated work skills, read-only context
+**Distribution is released; complete host support remains unverified.** The v1.97.13 artifacts establish package availability, not a successful install, trust, workflow, update or removal journey in a particular app. See [the maintained app guide](../../docs/HARNESS-PORTABILITY.md). The tools below do not include task writes, full meeting preparation, Doctor, feedback, onboarding, updates or session-end capture.
+
+The package distributed with Dex v1.97.13 carries Dex's generated work skills, read-only context
 tools, and shared safety gate into several agent harnesses. It keeps the Agent
 Plugins v1 root contract and also includes native manifests for:
 
@@ -26,12 +28,14 @@ Plugins v1 root contract and also includes native manifests for:
 The MCP bridge exposes `boot_today`, `get_person_context`,
 `check_safety_gate`, and `dex_harness_profiles`. It is dependency-free,
 relocatable, read-only, and uses the same vendored source modules as dex-core.
-The safety MCP tool is advisory unless the host calls it before acting; the
-native Codex/Claude `PreToolUse` hook can actively refuse known-dangerous work.
+The safety MCP tool is advisory; only a trusted interceptor that runs before
+the action and honors the refusal can enforce it. The
+native Codex/Claude `PreToolUse` adapter expresses a refusal, whose actual host
+interception and tool coverage still require native verification.
 
 ## Release platforms
 
-This unreleased build requires Node 20+ and Python 3.11+. Its Node launcher
+This package requires Node 20+ and Python 3.11+. Its Node launcher
 selects `python3`/`python` on macOS and `py -3`/`python` on Windows without
 invoking a shell, so installed paths containing spaces remain one argument.
 
@@ -44,13 +48,11 @@ invoking a shell, so installed paths containing spaces remain one argument.
 The versioned source of truth is `metadata/harnesses/registry.json`. Doctor
 reports the current platform boundary alongside the saved harness receipt.
 
-ChatGPT Work desktop can load this same local plugin after a person copies it
-into `~/.codex/plugins/dex`, lists it from `~/.agents/plugins/marketplace.json`
-with `source.path` `./.codex/plugins/dex`, restarts the ChatGPT desktop app,
-installs Dex from that local source, starts Work locally, and grants the Dex
-vault folder. That desktop journey has not been recorded yet. ChatGPT web
-needs a separately hosted HTTPS MCP service before it can reach a local Dex
-vault; this repository does not claim that remote bridge.
+The candidate ChatGPT Work desktop recipe is documented in the maintained app
+guide. A real desktop must prove local execution, folder access and the required
+runtime; a shared plugin cache is not that evidence. ChatGPT web needs a
+separately hosted HTTPS MCP service before it can reach a local Dex vault;
+this package does not provide that remote bridge.
 
 Regenerate and verify it from the repository root:
 

--- a/packages/dex-claude-desktop/README.md
+++ b/packages/dex-claude-desktop/README.md
@@ -1,7 +1,7 @@
 # Dex for Claude Desktop
 
-This source directory becomes the unreleased `dex-claude-desktop.mcpb` local
-extension. It exposes four read-only Dex MCP tools and asks the user to select
+This source directory builds the `dex-claude-desktop.mcpb` local extension
+distributed with v1.97.13. It exposes four read-only Dex MCP tools and asks the user to select
 their Dex folder during installation. Claude Desktop chat does not run lifecycle
 hooks, so this artifact makes no hook or automatic-safety claim.
 
@@ -22,4 +22,4 @@ artifact.
 
 To test the reviewed artifact without publishing it, open Claude Desktop and use
 **Settings > Extensions > Advanced settings > Install Extension**. Select the
-Dex folder when prompted. This developer-preview journey is not a release.
+Dex folder when prompted. Artifact publication is distinct from this still-unverified native install journey.

--- a/packages/dex-contracts/README.md
+++ b/packages/dex-contracts/README.md
@@ -1,5 +1,7 @@
 # @dex/contracts
 
+This contributor package exports the generated contracts listed below. The app capability registry and portable MCP bridge live separately under `core/harnesses/` and `packages/dex-agent-plugin/`; this package does not export a complete host workflow API. Generated output proves its declared format, not native app support.
+
 Shared cross-repo contract package.
 
 ## Build

--- a/packages/dex-gemini-extension/README.md
+++ b/packages/dex-gemini-extension/README.md
@@ -1,6 +1,6 @@
 # Dex for Gemini CLI
 
-This source overlay becomes the unreleased installable Gemini CLI extension. The
+This source overlay builds the Gemini CLI extension distributed with v1.97.13. The
 artifact builder combines it with Dex's canonical skills, read-only MCP runtime,
 and shared context/safety bridge so those files do not drift into a fork.
 
@@ -16,5 +16,5 @@ gemini extensions install build/portable-artifacts/dex-gemini-extension
 
 Restart Gemini CLI after installation and open the full Dex folder. Review the
 extension's `SessionStart` and `BeforeTool` hooks before consenting. The extension
-requires Node 20+ and Python 3.11+. This developer-preview journey is not a
-marketplace publication or release.
+requires Node 20+ and Python 3.11+. Package distribution is released; this developer-preview install journey is not
+certified native host support or marketplace publication.


### PR DESCRIPTION
## Linked Issue

Documentation maintenance; no public issue is needed for this scoped correction.

## What Changed

The README previously called already-distributed portable packages unreleased and implied the same automatic behavior across apps. It now starts with choosing an app and vault, getting a useful planning result, privacy and help. It distinguishes v1.97.13 package distribution from the still-unverified install, workflow, update and removal journeys in new apps.

Maintained system and package guides use the same boundaries. Established Claude Code and Cursor routes remain available; Windows manual setup explicitly selects Git Bash, and weekly commands distinguish review from planning. All 13 canonical system guides and compatibility copies match byte-for-byte.

## Test Plan

This changes 39 Markdown files; executable code and generated metadata are unchanged. Regression coverage is documentation validation and independent review rather than new implementation-mirroring tests.

- 100 relative file/anchor links and 13 compatibility pairs checked.
- Agent skills, portable package and portability metadata checks passed; architecture inventory regenerated outside the checkout and matched.
- PII/personal-config and founder-content checks passed on the initial candidate; the final repair changes only shell guidance and weekly-command wording.
- Independent Standards review accepted the full candidate. Independent Spec review found two retained documentation defects; a separate review accepted both repairs at ce61637f.
- Existing Linux portable runtime protocol check passed; no native app support is inferred. Eight entry/help/install URLs returned HTTP 200, which checks availability only.
- Native macOS/Windows installation and complete new-app workflows were NOT RUN. Required remote CI and automated team review remain outstanding.

## Ralph Wiggum Loop

- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I requested specialist review for risky areas (testing/infra/security when relevant).
- [x] I addressed review findings and re-ran checks.

## Quality Gates

- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback

Low: documentation only. Revert these documentation commits if necessary. New-app install recipes remain developer previews; package availability is not a support certification.

## Docs Impact

README, contributor/skill catalogue references, app capability and architecture guides, maintained system guides and their compatibility copies, plus package READMEs. Historical changelog/plans, product persona, installer code and generated output remain unchanged. Future verified host releases must update the explicitly versioned four-tool boundaries.
