### PR TITLE
Add opt-in GitHub CLI and VS Code hook translators

### DIFF
--- a/core/harnesses/copilot_hooks.py
+++ b/core/harnesses/copilot_hooks.py
@@ -1,0 +1,238 @@
+"""Documented GitHub CLI / VS Code hook translation, not a host support claim.
+
+The installed command supplies surface and event: native CLI payloads do not
+carry an event name, and CLI compatibility payloads cannot identify VS Code.
+Policy stays in core.gates.safety; this module never executes proposed actions.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.dont_write_bytecode = True
+if str(Path(__file__).resolve().parents[2]) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+SURFACES = ("copilot-cli", "vscode")
+EVENTS = {"preToolUse": "PreToolUse", "PreToolUse": "PreToolUse",
+          "sessionStart": "SessionStart", "SessionStart": "SessionStart",
+          "sessionEnd": "SessionEnd", "SessionEnd": "SessionEnd",
+          "agentStop": "Stop", "Stop": "Stop"}
+FAILURE = "Dex could not check this hook request. Check the selected vault and hook runtime."
+UNKNOWN_TOOL = "Dex cannot inspect this tool schema yet. Use a reviewed tool or the Dex service."
+SHELL = {"bash", "powershell", "Bash", "run_in_terminal", "runTerminalCommand"}
+FILES = {"create", "edit", "str_replace_editor", "Write", "Edit", "create_file",
+         "replace_string_in_file", "createFile", "editFiles", "multi_replace_string_in_file"}
+READS = {"view", "Read", "grep", "rg", "Grep", "glob", "Glob", "web_fetch", "WebFetch",
+         "web_search", "WebSearch", "ask_user", "AskUserQuestion", "update_todo", "TodoWrite"}
+PATH_ALIASES = {"filePath": "file_path", "notebookPath": "notebook_path",
+                "sourcePath": "source_path", "destinationPath": "destination_path"}
+
+
+def _string(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip() or "\x00" in value:
+        raise ValueError("invalid string")
+    return value  # Literal paths must retain whitespace and shell-like prefixes.
+
+
+def _object(value: Any) -> dict:
+    if not isinstance(value, dict):
+        raise ValueError("expected object")
+    return value
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict:
+    result: dict = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def parse_json(raw: str) -> Any:
+    def reject_constant(_value: str) -> None:
+        raise ValueError("invalid number")
+
+    return json.loads(raw, object_pairs_hook=_unique_object,
+                      parse_constant=reject_constant)
+
+
+def _validate_envelope(payload: dict, surface: str, configured_event: str) -> tuple[str, bool]:
+    if surface not in SURFACES or configured_event not in EVENTS:
+        raise ValueError("unknown host/event")
+    event = EVENTS[configured_event]
+    if surface == "vscode" and event == "SessionEnd":
+        raise ValueError("VS Code has no documented session-end event")
+    native = surface == "copilot-cli" and configured_event[0].islower()
+    common = {"timestamp", "cwd", "vault_path", "workspace_roots"}
+    common |= {"sessionId"} if native else {"session_id", "hook_event_name", "transcript_path"}
+    specific = {
+        "PreToolUse": {"toolName", "toolArgs"} if native else {"tool_name", "tool_input", "tool_use_id"},
+        "SessionStart": {"source", "initialPrompt" if native else "initial_prompt"},
+        "SessionEnd": {"reason"},
+        "Stop": {"stop_hook_active", "transcriptPath", "stopReason"} if native else {"stop_hook_active", "stop_reason"},
+    }
+    if payload.keys() - common - specific[event]:
+        raise ValueError("unknown envelope fields")
+    if native:
+        if any(key in payload for key in ("hook_event_name", "session_id", "tool_name", "tool_input")):
+            raise ValueError("mixed payload formats")
+        _string(payload.get("sessionId"))
+        stamp = payload.get("timestamp")
+        if type(stamp) not in (int, float) or not math.isfinite(stamp):
+            raise ValueError("invalid timestamp")
+        _string(payload.get("cwd"))
+    else:
+        if any(key in payload for key in ("sessionId", "toolName", "toolArgs")):
+            raise ValueError("mixed payload formats")
+        if payload.get("hook_event_name") != event:
+            raise ValueError("conflicting event")
+        _string(payload.get("timestamp"))
+        if surface == "copilot-cli" or "session_id" in payload:
+            _string(payload.get("session_id"))
+    # Do not accept a second spelling capable of contradicting the command.
+    if "hookEventName" in payload:
+        raise ValueError("unexpected event alias")
+    if "cwd" in payload:
+        _string(payload["cwd"])
+    if "vault_path" in payload:
+        _string(payload["vault_path"])
+    if event == "PreToolUse" and "cwd" not in payload:
+        raise ValueError("cannot resolve relative tool targets without host cwd")
+    return event, native
+
+
+def _inputs(tool: str, arguments: Any, native: bool) -> list[tuple[str, dict]]:
+    # CLI toolArgs is unknown in the reference, and may be a JSON string.
+    if isinstance(arguments, str):
+        if tool in {"apply_patch", "Edit"} and arguments.startswith("*** Begin Patch"):
+            arguments = {"patch": arguments}
+        elif native:
+            arguments = parse_json(arguments)
+    args = dict(_object(arguments))
+    for source, destination in PATH_ALIASES.items():
+        if source in args:
+            if destination in args and args[source] != args[destination]:
+                raise ValueError("conflicting target aliases")
+            args[destination] = args.pop(source)
+    if tool not in SHELL | FILES | READS | {"apply_patch"}:
+        raise ValueError(UNKNOWN_TOOL)
+    # PascalCase CLI maps apply_patch to Edit; its patch data still needs the
+    # canonical patch parser, not the single-file Edit path.
+    patch = tool == "apply_patch" or (tool == "Edit" and any(k in args for k in ("patch", "input")))
+    if tool == "Edit" and isinstance(args.get("command"), str) and args["command"].startswith("*** Begin Patch"):
+        patch = True
+    canonical = "apply_patch" if patch else "Bash" if tool in SHELL else "Write" if tool in FILES else tool
+    inputs = [(canonical, args)]
+    if "files" in args:
+        files = args["files"]
+        if not isinstance(files, list) or not files:
+            raise ValueError("invalid files")
+        # Keep any independent top-level target; do not overwrite it with a
+        # safe member of the array and lose an unsafe path.
+        inputs = [("Read", args), *[(canonical, {**args, "path": _string(path)}) for path in files]]
+    if "replacements" in args:
+        rows = args["replacements"]
+        if tool != "multi_replace_string_in_file" or not isinstance(rows, list) or not rows:
+            raise ValueError("invalid replacements")
+        # Check top-level exposed fields too; they must not disappear when the
+        # batch is flattened. Each row must have an inspectable file target.
+        if "files" not in args:
+            inputs = [("Read", args)]
+        for row in rows:
+            inputs.extend(_inputs("replace_string_in_file", row, False))
+    return inputs
+
+
+def _denial(surface: str, reason: str) -> dict:
+    decision = {"permissionDecision": "deny", "permissionDecisionReason": reason}
+    if surface == "vscode":
+        return {"hookSpecificOutput": {"hookEventName": "PreToolUse", **decision}}
+    return decision
+
+
+def handle(payload: Any, *, surface: str, event: str) -> dict:
+    """Translate one event; any malformed/unknown input raises before action."""
+    payload = _object(payload)
+    normalized, native = _validate_envelope(payload, surface, event)
+    if normalized == "PreToolUse":
+        from core.gates.safety import evaluate_hook_payload
+
+        tool = _string(payload.get("toolName" if native else "tool_name"))
+        inputs = _inputs(tool, payload.get("toolArgs" if native else "tool_input"), native)
+        warning = ""
+        for canonical, arguments in inputs:
+            request = {key: payload[key] for key in ("cwd", "vault_path", "workspace_roots") if key in payload}
+            request.update(hook_event_name="PreToolUse", tool_name=canonical, tool_input=arguments)
+            decision = evaluate_hook_payload(request)
+            if decision.refused:
+                return _denial(surface, decision.reason)
+            warning = decision.reason or warning
+        # A policy pass must retain the host's ordinary approval flow. An
+        # explicit 'allow' can auto-approve a tool in VS Code.
+        if warning:
+            return {"systemMessage": warning} if surface == "vscode" else {"permissionDecisionReason": warning}
+        return {}
+    if normalized == "SessionStart":
+        from core.vault_selection import select_vault
+
+        source = payload.get("source")
+        if source not in (("new",) if surface == "vscode" else ("startup", "resume", "new")):
+            raise ValueError("unknown session source")
+        # No cwd from VS Code must not turn the plugin cache into a vault.
+        if "cwd" not in payload:
+            import os
+
+            if not any(os.environ.get(k) for k in ("DEX_VAULT_PATH", "VAULT_PATH", "CLAUDE_PROJECT_DIR")):
+                raise ValueError("missing vault binding")
+        root = select_vault(explicit=payload.get("vault_path"), cwd=payload.get("cwd"),
+                            workspace_roots=payload.get("workspace_roots"))
+        from core.context.session_boot import build_session_boot
+
+        context = build_session_boot(root)["injected_text"]
+        if not isinstance(context, str):
+            raise ValueError("invalid shared context")
+        if not context:
+            return {}
+        return ({"additionalContext": context} if surface == "copilot-cli" else
+                {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": context}})
+    if normalized == "SessionEnd":
+        if payload.get("reason") not in ("complete", "error", "abort", "timeout", "user_exit"):
+            raise ValueError("unknown end reason")
+    elif normalized == "Stop":
+        if type(payload.get("stop_hook_active")) is not bool:
+            raise ValueError("invalid stop flag")
+        if surface == "copilot-cli" and payload.get("stopReason" if native else "stop_reason") != "end_turn":
+            raise ValueError("unknown turn stop reason")
+    # Deliberate no-op: neither event authorizes an autocommit, checkpoint, or
+    # transcript read. Stop never becomes SessionEnd.
+    return {}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--surface", required=True, choices=SURFACES)
+    parser.add_argument("--event", required=True, choices=EVENTS)
+    args = parser.parse_args(argv)
+    try:
+        raw = sys.stdin.read(1024 * 1024 + 1)
+        if len(raw) > 1024 * 1024:
+            raise ValueError("oversized hook")
+        output = handle(parse_json(raw), surface=args.surface, event=args.event)
+    except Exception:
+        # No input, private paths, tool arguments or tracebacks in diagnostics.
+        sys.stderr.write(FAILURE + "\n")
+        output = _denial(args.surface, FAILURE)
+        sys.stdout.write(json.dumps(output) + "\n")
+        return 2  # VS Code treats other nonzero exits as non-blocking warnings.
+    sys.stdout.write(json.dumps(output, ensure_ascii=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/harnesses/templates/copilot/cli-hooks.json
+++ b/core/harnesses/templates/copilot/cli-hooks.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [{"type": "command", "command": "node \"${PLUGIN_ROOT}/bin/dex-copilot-hook.mjs\" --surface copilot-cli --event preToolUse", "timeoutSec": 15}],
+    "sessionStart": [{"type": "command", "command": "node \"${PLUGIN_ROOT}/bin/dex-copilot-hook.mjs\" --surface copilot-cli --event sessionStart", "timeoutSec": 15}],
+    "sessionEnd": [{"type": "command", "command": "node \"${PLUGIN_ROOT}/bin/dex-copilot-hook.mjs\" --surface copilot-cli --event sessionEnd", "timeoutSec": 15}],
+    "agentStop": [{"type": "command", "command": "node \"${PLUGIN_ROOT}/bin/dex-copilot-hook.mjs\" --surface copilot-cli --event agentStop", "timeoutSec": 15}]
+  }
+}

--- a/core/harnesses/templates/copilot/dex-copilot-hook.mjs
+++ b/core/harnesses/templates/copilot/dex-copilot-hook.mjs
@@ -1,0 +1,67 @@
+// Canonical source: copy to the assembled plugin's bin/ directory.
+// Capture the checker output so failures cannot leak partial/invalid decisions.
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const reason = "Dex could not check this hook request. Check the selected vault and hook runtime.";
+const args = process.argv.slice(2);
+const surface = args[1];
+const event = args[3];
+const valid = args.length === 4 && args[0] === "--surface" && args[2] === "--event"
+  && ["copilot-cli", "vscode"].includes(surface)
+  && ["preToolUse", "PreToolUse", "sessionStart", "SessionStart", "sessionEnd", "SessionEnd", "agentStop", "Stop"].includes(event);
+
+function fail() {
+  const decision = { permissionDecision: "deny", permissionDecisionReason: reason };
+  const output = surface === "vscode"
+    ? { hookSpecificOutput: { hookEventName: "PreToolUse", ...decision } } : decision;
+  process.stderr.write(`${reason}\n`);
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+  process.exitCode = 2;
+}
+
+function validOutput(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const keysAre = (object, keys) => Object.keys(object).length === keys.length
+    && keys.every((key) => Object.hasOwn(object, key));
+  if (Object.keys(value).length === 0) return true;
+  const fields = surface === "vscode" ? value.hookSpecificOutput : value;
+  if (fields?.permissionDecision === "deny" && typeof fields.permissionDecisionReason === "string"
+      && fields.permissionDecisionReason.length > 0) {
+    return surface === "vscode"
+      ? keysAre(value, ["hookSpecificOutput"]) && keysAre(fields, ["hookEventName", "permissionDecision", "permissionDecisionReason"])
+        && fields.hookEventName === "PreToolUse"
+      : keysAre(value, ["permissionDecision", "permissionDecisionReason"]);
+  }
+  if (["sessionStart", "SessionStart"].includes(event) && typeof fields?.additionalContext === "string") {
+    return surface === "vscode"
+      ? keysAre(value, ["hookSpecificOutput"]) && keysAre(fields, ["hookEventName", "additionalContext"])
+        && fields.hookEventName === "SessionStart"
+      : keysAre(value, ["additionalContext"]);
+  }
+  if (!["preToolUse", "PreToolUse"].includes(event)) return false;
+  return surface === "vscode" ? keysAre(value, ["systemMessage"]) && typeof value.systemMessage === "string"
+    : keysAre(value, ["permissionDecisionReason"]) && typeof value.permissionDecisionReason === "string";
+}
+
+try {
+  if (!valid) throw new Error("invalid invocation");
+  const { pythonCandidates } = await import("./dex-launcher-lib.mjs");
+  const input = readFileSync(0, "utf8");
+  if (Buffer.byteLength(input) > 1024 * 1024) throw new Error("oversized input");
+  const script = fileURLToPath(new URL("../runtime/core/harnesses/copilot_hooks.py", import.meta.url));
+  let result;
+  for (const candidate of pythonCandidates()) {
+    result = spawnSync(candidate.command, [...candidate.args, script, ...args], {
+      input, encoding: "utf8", windowsHide: true, timeout: 8000, maxBuffer: 1024 * 1024,
+    });
+    if (result.error?.code !== "ENOENT") break;
+  }
+  if (!result || result.error || result.status !== 0) throw new Error("checker failed");
+  const output = JSON.parse(result.stdout);
+  if (!validOutput(output)) throw new Error("invalid checker output");
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+} catch {
+  fail();
+}

--- a/core/harnesses/templates/copilot/vscode-hooks.json
+++ b/core/harnesses/templates/copilot/vscode-hooks.json
@@ -1,0 +1,7 @@
+{
+  "hooks": {
+    "PreToolUse": [{"type": "command", "command": "node \"${PLUGIN_ROOT}/bin/dex-copilot-hook.mjs\" --surface vscode --event PreToolUse", "timeout": 15}],
+    "SessionStart": [{"type": "command", "command": "node \"${PLUGIN_ROOT}/bin/dex-copilot-hook.mjs\" --surface vscode --event SessionStart", "timeout": 15}],
+    "Stop": [{"type": "command", "command": "node \"${PLUGIN_ROOT}/bin/dex-copilot-hook.mjs\" --surface vscode --event Stop", "timeout": 15}]
+  }
+}

--- a/core/tests/test_copilot_hook_protocol.py
+++ b/core/tests/test_copilot_hook_protocol.py
@@ -1,0 +1,298 @@
+"""Run the real hook boundary with proposals; never execute those proposals."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+TEMPLATES = ROOT / "core/harnesses/templates/copilot"
+MODES = [("copilot-cli", "preToolUse"), ("copilot-cli", "PreToolUse"), ("vscode", "PreToolUse")]
+
+
+@pytest.fixture
+def fixture(tmp_path, monkeypatch):
+    for key in ("DEX_VAULT_PATH", "VAULT_PATH", "CLAUDE_PROJECT_DIR", "PYTHONPATH"):
+        monkeypatch.delenv(key, raising=False)
+    package = tmp_path / "plugin with spaces"
+    (package / "bin").mkdir(parents=True)
+    shutil.copyfile(TEMPLATES / "dex-copilot-hook.mjs", package / "bin/dex-copilot-hook.mjs")
+    shutil.copyfile(ROOT / "packages/dex-agent-plugin/bin/dex-launcher-lib.mjs", package / "bin/dex-launcher-lib.mjs")
+    for relative in ("core/__init__.py", "core/path_safety.py", "core/vault_selection.py", "core/paths.py",
+                     "core/harnesses/__init__.py", "core/harnesses/copilot_hooks.py",
+                     "core/gates/__init__.py", "core/gates/safety.py",
+                     "core/context/__init__.py", "core/context/person_context.py", "core/context/session_boot.py"):
+        target = package / "runtime" / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(ROOT / relative, target)
+    vault = tmp_path / "selected"
+    decoy = tmp_path / "decoy"
+    for location in (vault, decoy):
+        (location / "System").mkdir(parents=True)
+        (location / "System/pillars.yaml").write_text(f"pillars:\n  - id: test\n    name: {location.name}\n")
+    return package, vault, decoy
+
+
+def payload(vault, surface, event, tool=None, arguments=None, **extra):
+    native = surface == "copilot-cli" and event[0].islower()
+    result = {"cwd": str(vault), "timestamp": 1 if native else "2026-09-07T12:00:00Z"}
+    result["sessionId" if native else "session_id"] = "synthetic-session"
+    if not native:
+        result["hook_event_name"] = event
+    if tool is not None:
+        result["toolName" if native else "tool_name"] = tool
+        result["toolArgs" if native else "tool_input"] = arguments
+    return {**result, **extra}
+
+
+def invoke(fixture, surface, event, request, *, env=None):
+    package, vault, _ = fixture
+    result = subprocess.run(
+        ["node", str(package / "bin/dex-copilot-hook.mjs"), "--surface", surface, "--event", event],
+        cwd=vault, input=request if isinstance(request, str) else json.dumps(request), text=True,
+        capture_output=True, timeout=12, env={**os.environ, "DEX_PYTHON": sys.executable, **(env or {})},
+    )
+    output = json.loads(result.stdout)
+    assert len(result.stdout.splitlines()) == 1
+    return result, output
+
+
+def assert_denied(result, output, surface):
+    fields = output["hookSpecificOutput"] if surface == "vscode" else output
+    assert fields["permissionDecision"] == "deny"
+    assert fields["permissionDecisionReason"]
+    if surface == "vscode":
+        assert fields["hookEventName"] == "PreToolUse"
+        assert "permissionDecision" not in output
+    else:
+        assert "hookSpecificOutput" not in output
+    assert result.returncode in (0, 2)
+
+
+@pytest.mark.parametrize("surface,event", MODES)
+@pytest.mark.parametrize("command,blocked", [("rm -rf /", True), ("gh repo delete example/synthetic", True),
+                                            ("git status", False), ("printf safe", False)])
+def test_shell_proposals_use_canonical_policy(fixture, surface, event, command, blocked):
+    _, vault, _ = fixture
+    tool = "runTerminalCommand" if surface == "vscode" else "bash" if event == "preToolUse" else "Bash"
+    result, output = invoke(fixture, surface, event, payload(vault, surface, event, tool, {"command": command}))
+    if blocked:
+        assert_denied(result, output, surface)
+    else:
+        assert result.returncode == 0
+        assert output == {}  # No host auto-approval.
+
+
+@pytest.mark.parametrize("surface,event,tool,key", [
+    ("copilot-cli", "preToolUse", "create", "path"),
+    ("copilot-cli", "PreToolUse", "Write", "file_path"),
+    ("vscode", "PreToolUse", "create_file", "filePath"),
+    ("vscode", "PreToolUse", "replace_string_in_file", "filePath"),
+])
+def test_file_targets_and_selected_vault(fixture, surface, event, tool, key):
+    _, vault, decoy = fixture
+    for target, blocked in [(str(decoy / "sentinel"), True), ("sentinel", False)]:
+        result, output = invoke(fixture, surface, event, payload(vault, surface, event, tool, {key: target}))
+        if blocked:
+            assert_denied(result, output, surface)
+        else:
+            assert output == {}
+        assert not (vault / "sentinel").exists()
+        assert not (decoy / "sentinel").exists()
+    result, output = invoke(fixture, surface, event, payload(decoy, surface, event, tool, {key: "sentinel"}),
+                            env={"DEX_VAULT_PATH": str(vault)})
+    assert_denied(result, output, surface)
+
+
+@pytest.mark.parametrize("tool,args", [
+    ("editFiles", {"files": ["safe", "../decoy/sentinel"]}),
+    ("editFiles", {"path": "../decoy/sentinel", "files": ["safe"]}),
+    ("create_file", {"filePath": "safe", "file_path": "../decoy/sentinel"}),
+    ("multi_replace_string_in_file", {"replacements": [{"filePath": "safe"}, {"filePath": "../decoy/sentinel"}]}),
+    ("multi_replace_string_in_file", {"destinationPath": "../decoy/sentinel", "replacements": [{"filePath": "safe"}]}),
+    ("multi_replace_string_in_file", {"files": ["../decoy/sentinel"], "replacements": [{"filePath": "safe"}]}),
+])
+def test_every_batch_target_is_checked(fixture, tool, args):
+    _, vault, decoy = fixture
+    result, output = invoke(fixture, "vscode", "PreToolUse", payload(vault, "vscode", "PreToolUse", tool, args))
+    assert_denied(result, output, "vscode")
+    assert not (decoy / "sentinel").exists()
+
+
+@pytest.mark.parametrize("tool,args", [("editFiles", {"files": ["one", "two"]}),
+    ("multi_replace_string_in_file", {"replacements": [{"filePath": "one"}, {"filePath": "two"}]}),
+    ("view", {"path": "one"})])
+def test_allowed_batch_and_read_controls(fixture, tool, args):
+    _, vault, _ = fixture
+    result, output = invoke(fixture, "vscode", "PreToolUse", payload(vault, "vscode", "PreToolUse", tool, args))
+    assert result.returncode == 0 and output == {}
+
+
+@pytest.mark.parametrize("surface,event", MODES)
+def test_live_migration_lock_is_shared(fixture, surface, event):
+    _, vault, _ = fixture
+    (vault / "System/.dex").mkdir()
+    (vault / "System/.dex/mutation.lock").write_text(json.dumps({"kind": "migration", "pid": os.getpid()}))
+    tool = "runTerminalCommand" if surface == "vscode" else "bash" if event == "preToolUse" else "Bash"
+    result, output = invoke(fixture, surface, event, payload(vault, surface, event, tool, {"command": "git reset --hard"}))
+    assert_denied(result, output, surface)
+    assert "migration" in result.stdout
+
+
+def test_relative_path_uses_host_cwd_and_allows_vault_descendant(fixture):
+    _, vault, _ = fixture
+    child = vault / "child"
+    child.mkdir()
+    for target, blocked in [("../safe", False), ("../../decoy/sentinel", True)]:
+        result, output = invoke(fixture, "vscode", "PreToolUse", payload(child, "vscode", "PreToolUse", "create_file", {"filePath": target}),
+                                env={"DEX_VAULT_PATH": str(vault)})
+        if blocked:
+            assert_denied(result, output, "vscode")
+        else:
+            assert result.returncode == 0 and output == {}
+
+
+@pytest.mark.parametrize("surface,event", MODES)
+def test_patch_targets_including_moves(fixture, surface, event):
+    _, vault, _ = fixture
+    tool = "Edit" if surface == "copilot-cli" and event == "PreToolUse" else "apply_patch"
+    for destination, blocked in [("sentinel", False), ("../decoy/sentinel", True)]:
+        patch = f"*** Begin Patch\n*** Update File: safe\n*** Move to: {destination}\n@@\n-a\n+b\n*** End Patch"
+        result, output = invoke(fixture, surface, event, payload(vault, surface, event, tool, {"input": patch}))
+        if blocked:
+            assert_denied(result, output, surface)
+        else:
+            assert output == {}
+
+
+@pytest.mark.parametrize("surface,event", MODES)
+def test_literal_symlink_names_are_not_expanded_or_trimmed(fixture, surface, event):
+    _, vault, decoy = fixture
+    for name in ("$ALIAS", " strange ", "~literal"):
+        (vault / name).symlink_to(decoy, target_is_directory=True)
+        tool = "create_file" if surface == "vscode" else "create" if event == "preToolUse" else "Write"
+        result, output = invoke(fixture, surface, event, payload(vault, surface, event, tool, {"path": f"{name}/sentinel"}))
+        assert_denied(result, output, surface)
+
+
+@pytest.mark.parametrize("tool,args", [("create_file", {}), ("editFiles", {"files": []}),
+    ("editFiles", {"files": [None]}), ("runTerminalCommand", {"command": []}),
+    ("apply_patch", {"input": "not a patch"}), ("new_tool", {}),
+    ("mcp__unknown__write", {"opaque": "destination"}), ("create_file", {"filePath": None}),
+    ("multi_replace_string_in_file", {"replacements": [{}]})])
+def test_unknown_and_malformed_tool_schemas_refuse(fixture, tool, args):
+    _, vault, _ = fixture
+    result, output = invoke(fixture, "vscode", "PreToolUse", payload(vault, "vscode", "PreToolUse", tool, args))
+    assert_denied(result, output, "vscode")
+
+
+@pytest.mark.parametrize("raw", ["", "null", "[]", "{", '{"cwd":"a","cwd":"b"}', "NaN"])
+@pytest.mark.parametrize("surface,event", MODES)
+def test_invalid_json_is_single_denial(fixture, surface, event, raw):
+    result, output = invoke(fixture, surface, event, raw)
+    assert_denied(result, output, surface)
+    assert result.returncode == 2
+
+
+@pytest.mark.parametrize("change", [{"hook_event_name": "SessionStart"}, {"toolName": "create"},
+    {"cwd": None}, {"tool_input": "{}"}, {"tool_name": ""}, {"timestamp": False}, {"unknown": 42}])
+def test_conflicting_or_unknown_envelopes_refuse(fixture, change):
+    _, vault, _ = fixture
+    request = payload(vault, "vscode", "PreToolUse", "create_file", {"filePath": "safe"})
+    result, output = invoke(fixture, "vscode", "PreToolUse", {**request, **change})
+    assert_denied(result, output, "vscode")
+
+
+def test_native_cli_string_arguments(fixture):
+    _, vault, _ = fixture
+    request = payload(vault, "copilot-cli", "preToolUse", "bash", '{"command":"rm -rf /"}')
+    result, output = invoke(fixture, "copilot-cli", "preToolUse", request)
+    assert_denied(result, output, "copilot-cli")
+
+
+@pytest.mark.parametrize("surface,event,source", [("copilot-cli", "sessionStart", "resume"),
+    ("copilot-cli", "SessionStart", "startup"), ("vscode", "SessionStart", "new")])
+def test_session_context_comes_from_shared_selected_vault(fixture, surface, event, source):
+    _, vault, decoy = fixture
+    result, output = invoke(fixture, surface, event, payload(vault, surface, event, source=source))
+    assert result.returncode == 0
+    context = output["additionalContext"] if surface == "copilot-cli" else output["hookSpecificOutput"]["additionalContext"]
+    assert "selected" in context and "decoy" not in context
+    result, output = invoke(fixture, surface, event, payload(decoy, surface, event, source=source),
+                            env={"DEX_VAULT_PATH": str(vault)})
+    assert_denied(result, output, surface)
+    assert str(vault) not in result.stdout and str(decoy) not in result.stdout
+    assert context not in result.stdout
+
+
+@pytest.mark.parametrize("surface,event,extra", [("copilot-cli", "sessionEnd", {"reason": "complete"}),
+    ("copilot-cli", "SessionEnd", {"reason": "user_exit"}),
+    ("copilot-cli", "agentStop", {"stopReason": "end_turn", "stop_hook_active": False}),
+    ("vscode", "Stop", {"stop_hook_active": True})])
+def test_finish_events_do_not_persist_or_restart(fixture, surface, event, extra):
+    _, vault, _ = fixture
+    before = sorted(p.relative_to(vault) for p in vault.rglob("*"))
+    result, output = invoke(fixture, surface, event, payload(vault, surface, event, **extra))
+    assert result.returncode == 0 and output == {}
+    assert before == sorted(p.relative_to(vault) for p in vault.rglob("*"))
+
+
+@pytest.mark.parametrize("event,extra", [("SessionStart", {"source": "resume"}),
+    ("SessionEnd", {"reason": "complete"}), ("Stop", {"stop_hook_active": "false"})])
+def test_vscode_unavailable_lifecycle_contracts_refuse(fixture, event, extra):
+    _, vault, _ = fixture
+    result, output = invoke(fixture, "vscode", event, payload(vault, "vscode", event, **extra))
+    assert_denied(result, output, "vscode")
+
+
+@pytest.mark.parametrize("broken", ["raise RuntimeError('private-payload')", "print('not json')", "print('{}{}')",
+    "print('[]')", "print('{\"permissionDecision\":\"allow\"}')", "print('{\"invented\":true}')",
+    "print('{\"systemMessage\":\"ok\",\"hookSpecificOutput\":{\"permissionDecision\":\"allow\"}}')"])
+def test_checker_failures_and_unknown_outputs_are_converted(fixture, broken):
+    package, vault, _ = fixture
+    (package / "runtime/core/harnesses/copilot_hooks.py").write_text(broken)
+    result, output = invoke(fixture, "vscode", "PreToolUse", payload(vault, "vscode", "PreToolUse", "create_file", {"path": "safe"}))
+    assert_denied(result, output, "vscode")
+    assert result.returncode == 2 and "private-payload" not in result.stderr
+
+
+def test_child_timeout_becomes_denial_before_host_deadline(fixture):
+    package, vault, _ = fixture
+    (package / "runtime/core/harnesses/copilot_hooks.py").write_text("import time\ntime.sleep(30)\n")
+    result, output = invoke(fixture, "copilot-cli", "preToolUse", payload(vault, "copilot-cli", "preToolUse", "create", {"path": "safe"}))
+    assert_denied(result, output, "copilot-cli")
+    assert result.returncode == 2
+    assert not (vault / "safe").exists()
+
+
+def test_context_import_failure_does_not_disable_pretool_safety(fixture):
+    package, vault, _ = fixture
+    (package / "runtime/core/context/session_boot.py").write_text("raise RuntimeError('broken context')")
+    result, output = invoke(fixture, "copilot-cli", "preToolUse", payload(vault, "copilot-cli", "preToolUse", "bash", {"command": "rm -rf /"}))
+    assert_denied(result, output, "copilot-cli")
+    assert result.returncode == 0
+
+
+def test_missing_launcher_dependency_is_blocking_in_vscode(fixture):
+    package, vault, _ = fixture
+    (package / "bin/dex-launcher-lib.mjs").unlink()
+    result, output = invoke(fixture, "vscode", "PreToolUse", payload(vault, "vscode", "PreToolUse", "create_file", {"filePath": "safe"}))
+    assert_denied(result, output, "vscode")
+    assert result.returncode == 2
+
+
+def test_templates_have_explicit_surface_event_and_no_matcher():
+    for file, surface in [("cli-hooks.json", "copilot-cli"), ("vscode-hooks.json", "vscode")]:
+        template = json.loads((TEMPLATES / file).read_text())
+        for event, entries in template["hooks"].items():
+            assert len(entries) == 1
+            command = entries[0]["command"]
+            assert f"--surface {surface} --event {event}" in command
+            assert "matcher" not in entries[0]
+        if surface == "vscode":
+            assert "SessionEnd" not in template["hooks"]

--- a/docs/contracts/copilot-hook-adapter.md
+++ b/docs/contracts/copilot-hook-adapter.md
@@ -1,0 +1,105 @@
+# GitHub hook adapter candidate
+
+This is an experimental translator contract, not verified GitHub host support.
+The CLI, VS Code and GitHub Copilot app remain separate acceptance rows. No
+authenticated host session, installation, Windows/macOS execution or app trace
+was run for this change.
+
+## Source and assembly
+
+`core/harnesses/copilot_hooks.py` translates host inputs directly into
+`core.gates.safety.evaluate_hook_payload`; context comes from
+`core.context.session_boot.build_session_boot`, with the same
+`core.vault_selection.select_vault` policy. There is no second policy engine,
+transcript reader, task writer, autocommit or checkpoint implementation here.
+
+The assembler must copy these canonical files, preserving their relative paths:
+
+- `core/{__init__,paths,path_safety,vault_selection}.py` into `runtime/core/`.
+- `core/gates/{__init__,safety}.py` into `runtime/core/gates/`.
+- `core/context/{__init__,person_context,session_boot}.py` into `runtime/core/context/`.
+- `core/harnesses/{__init__,copilot_hooks}.py` into `runtime/core/harnesses/`.
+- `core/harnesses/templates/copilot/dex-copilot-hook.mjs` into `bin/`, beside the
+  existing `dex-launcher-lib.mjs`. The shim reuses its Python resolution contract.
+
+The two JSON source templates in that directory are alternatives. The CLI
+template selects `--surface copilot-cli`; the VS Code template selects
+`--surface vscode`. Both pass the configured event explicitly. This is required
+because native CLI events omit their name from the input, while CLI compatibility
+payloads overlap VS Code payloads. Do not infer surface from a matching schema.
+
+Do not activate either template as a universal GitHub hook configuration. A
+surface-specific assembly/install step must select one, avoid duplicate hooks,
+and prove discovery in that host. The Agent Plugins 1.0 location is
+`com.github.copilot/hooks/hooks.json`; `${PLUGIN_ROOT}` expands to the installed
+package. GitHub-specific component discovery and the shared namespace are
+documented in the [VS Code plugin reference](https://code.visualstudio.com/docs/agent-customization/agent-plugins).
+The root schema remains Agent Plugins 1.0; a top-level portable `hooks` manifest
+field is not a substitute for its client namespace.
+
+## Protocol boundary
+
+The CLI adapter accepts native camelCase event inputs (`toolName`, `toolArgs`),
+including object arguments serialized as JSON, and PascalCase compatibility
+inputs (`tool_name`, `tool_input`). Denials and session context use the CLI's
+flat response envelope in both modes. Native `apply_patch` and compatibility
+`Edit` patch data use the shared patch target parser. The documented event
+configuration version is 1. See the [GitHub hook reference](https://docs.github.com/en/copilot/reference/hooks-reference).
+
+VS Code uses `hookSpecificOutput` for a tool refusal and session context. The
+adapter normalizes `filePath` and related camelCase path fields, checks file
+arrays and replacement batches, and recognizes the documented file/terminal
+tool spellings. Matchers are omitted: filtering happens inside the adapter.
+See [VS Code hook configuration](https://code.visualstudio.com/docs/agent-customization/hooks)
+and its [event reference](https://code.visualstudio.com/docs/agents/reference/hooks-reference).
+
+An accepted pre-tool proposal returns `{}`, preserving the host's normal
+permission flow instead of automatically approving execution. Invalid JSON,
+duplicate keys, conflicting event/input aliases, unknown envelope fields,
+unknown tool schemas and uninspectable targets refuse. Opaque MCP schemas are
+also refused; actual MCP names/arguments must be captured and reviewed before
+adding them. This limitation prevents claiming a complete GitHub Dex workflow.
+Proposed commands and writes are never executed by the adapter or its tests.
+
+Relative targets require the host's `cwd`. A configured vault and a conflicting
+working directory refuse; a descendant directory is accepted. VS Code's
+optional missing `cwd` is refused for pre-tool events. Session start without
+`cwd` requires an existing vault environment binding, avoiding plugin-cache
+fallback. Unknown schema evolution therefore fails conservatively until reviewed.
+
+The CLI's `sessionEnd` and `agentStop` are distinct. VS Code's `Stop` does not
+establish session termination; its documented SessionStart source is `new`.
+Finish events currently validate and return `{}` without persistence. Do not
+advertise checkpoint or resume-context parity from these no-op handlers.
+
+## Failure limits and acceptance
+
+The Node shim captures one final checker response. Crashes, missing runtime
+dependencies, invalid/unknown outputs and an eight-second child timeout become
+a denial with exit 2. It never forwards private arguments, paths or tracebacks.
+The source templates give the host fifteen seconds.
+
+This does not guarantee interception: CLI command-hook timeouts fail open,
+HTTP hook failures fail open, and invalid/empty final output can fall through.
+If the outer launcher stalls, never starts, is disabled, or the host ignores
+the hook, its inner deadline cannot help. These are documented host limits,
+not failures this wrapper can override. Core-owned mutations must retain their
+own service-level checks. Shared shell checks recognize known patterns; they
+are not a shell sandbox or a proof of PowerShell-language coverage.
+
+Before any supported-host claim, capture real CLI, VS Code and app traces;
+test selected/decoy vaults, denial sentinel non-creation, ordinary allowed
+controls, hook crash/timeout, duplicate installations, disable/update/remove,
+and the intended workflow. Record exact app, extension, CLI and OS builds.
+App behavior is unknown until observed; CLI reuse is not app evidence.
+
+The CLI reserves `/feedback` for GitHub feedback and documents plugin-qualified
+skill names such as `/my-plugin/search`. With the current package name, test
+`/dex-agent-plugin/feedback` and prove the Dex intake receipt before documenting
+it as working. This is a candidate invocation, not an observed result. See the
+[CLI command reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference).
+
+Official references were re-read on 7 September 2026. GitHub's online hook and
+command references are unversioned; the VS Code pages display 2 September 2026
+and hooks remain Preview. These document dates do not establish a minimum
+working product build.


### PR DESCRIPTION
## Linked Issue
- Prerequisite: #715 (shared safety and selected-vault contract). This PR is stacked on `codex/de01-native-safety-fix` so its review diff contains only the six experimental adapter files. Retarget to `main` after the prerequisite lands; do not merge into the prerequisite branch.
- Implementation contract: `docs/contracts/copilot-hook-adapter.md`.

## What Changed
- Copilot CLI and VS Code use different hook inputs and responses. Add an explicit surface/event translator that converts their documented inputs into the canonical Core safety gate and returns each host's denial/context envelope.
- Check every exposed file/batch/patch target, reject malformed or unknown schemas, and return an empty decision on safe proposals to preserve the host's ordinary approval flow. Session context uses shared vault selection; turn completion never becomes session termination or an automatic checkpoint.
- Add separate opt-in CLI/VS Code hook templates and a Node launcher that converts checker crashes, invalid output and an eight-second child timeout into a sanitized refusal. These are source artifacts; this PR does not install or activate them, change the generator/registry, or advertise host support.

## Test Plan
- Final reviewed head: `42f3a766a596f1512e0a5f8de74a35ed80b05c22`. Independent specification and Standards/security reviews accepted this exact six-file candidate with no actionable findings.
- **266 targeted tests passed**: 91 staged-package protocol cases plus 175 existing shared-safety cases. Proposals remain data; tests never execute the proposed write or shell command. Coverage includes safe controls, selected/decoy roots, literal symlinks, mixed file/replacement batches, patch moves, malformed inputs, missing helpers, crashes, corrupt output, child timeout and no-op finish events.
- Commands: `python -m pytest -p no:cacheprovider core/tests/test_copilot_hook_protocol.py core/tests/test_harness_safety_gates.py core/tests/test_harness_safety_parity.py -q`; scoped Ruff; `node --check core/harnesses/templates/copilot/dex-copilot-hook.mjs`; `bash scripts/check-portable-contract.sh`; PII and founder-content gates; `git diff --check`. Local environment: Linux, Node 22.23.2, Python 3.13.7, pytest 9.1.1.
- NOT RUN: authenticated Copilot CLI, VS Code/extension, GitHub Copilot app or cloud-agent acceptance; native macOS/Windows; real hook sentinel and host-timeout behavior; actual MCP inventory and feedback intake; install/update/remove, duplicate-configuration or recovery journeys. Mandatory remote CI and team review remain required.

## Ralph Wiggum Loop
- [x] I implemented the change.
- [x] I self-reviewed for defects and edge cases.
- [x] I requested specialist review for risky areas (testing/infra/security when relevant).
- [x] I addressed review findings and re-ran checks.

## Quality Gates
- [x] I added/updated tests or documented why no tests are needed.
- [x] I added a regression test for bug fixes, or this PR is not a bug fix.
- [x] I validated failure modes / edge cases.
- [x] I updated docs or confirmed no docs impact.
- [x] CI checks for lint + tests + coverage are expected to pass.

## Risk & Rollback
- Risk: medium at future activation. Unknown tool and MCP schemas deliberately refuse; a complete GitHub Dex workflow is not enabled. CLI, VS Code and the app share a namespace, so installation must explicitly choose a reviewed surface template. CLI code reuse cannot certify app behavior. Cloud-agent execution does not establish access to a local vault.
- CLI outer hook timeouts can fail open. An inner checker deadline cannot guarantee execution when the outer launcher stalls, never starts or the hook is disabled. Canonical Core mutation checks remain required; pattern-based shell checks are not a sandbox or a PowerShell coverage guarantee.
- Rollback: revert the additive adapter/template commit through the normal reviewed release route. No vault migration, credentials, global settings or installation state is changed by this PR.

## Docs Impact
- Added `docs/contracts/copilot-hook-adapter.md` with runtime assembly closure, separate template selection, current protocol references and explicit acceptance gaps. The documented qualified feedback invocation is a candidate requiring an actual Dex intake receipt.
- No version bump, release, deployment, activation or new support claim.
