### PR TITLE
Backup: one unreadable file costs that file, not the whole night's archive

### DIFF
--- a/core/backup/backup_vault.py
+++ b/core/backup/backup_vault.py
@@ -319,6 +319,40 @@ def _add_runbook(tar: tarfile.TarFile, vault: Path,
     tar.addfile(info, io.BytesIO(payload))
 
 
+def _add_vault_tree(tar: tarfile.TarFile, vault: Path, escaping: list[str],
+                    unreadable: list[str]) -> int:
+    """Add the vault to the archive one entry at a time; return how many files went in.
+
+    `tar.add(vault)` walks the whole tree inside one call, so the first file the
+    process is not allowed to read raises out of it and the archive is
+    abandoned with everything else unwritten. Adding entry by entry turns that
+    one file into a recorded gap instead of a lost night. The exclusion filter
+    is applied per entry exactly as before, and excluded directories are not
+    descended.
+    """
+    apply = _collecting_tar_filter(escaping)
+    added = 0
+    tar.add(vault, arcname=ARCNAME, recursive=False, filter=apply)
+    for root, dirs, files in os.walk(vault):
+        rel_root = Path(root).relative_to(vault)
+        dirs.sort()
+        files.sort()
+        dirs[:] = [d for d in dirs
+                   if not excluded(str(PurePosixPath(*(rel_root / d).parts)))]
+        for name in dirs + files:
+            path = Path(root) / name
+            relative = PurePosixPath(*(rel_root / name).parts)
+            try:
+                tar.add(path, arcname=f"{ARCNAME}/{relative}", recursive=False,
+                        filter=apply)
+            except OSError:
+                unreadable.append(str(relative))
+                continue
+            if path.is_file() and not path.is_symlink():
+                added += 1
+    return added
+
+
 def build_artifacts(vault: Path, workdir: Path, stamp: str,
                     warnings: list[str] | None = None) -> list[Path]:
     """Build the archive, the verified git bundle, and the checksum sidecar.
@@ -328,12 +362,31 @@ def build_artifacts(vault: Path, workdir: Path, stamp: str,
     warning, instead of aborting the run and storing nothing at all: a vault
     whose git repository has no commits yet, or is damaged, would otherwise
     get no backup whatsoever. An unverified bundle is never shipped.
+
+    The same rule applies inside the archive. A single file the scheduled
+    process cannot read (a per-file access list on an image saved by a
+    sandboxed app was the real case) must cost that file, not the whole
+    night's backup: it is skipped, named in a recorded warning, and the run
+    still stores everything else. Only a vault with nothing readable at all
+    fails the run.
     """
     archive = workdir / f"{PREFIX}{stamp}.tar.gz"
     escaping: list[str] = []
+    unreadable: list[str] = []
     with tarfile.open(archive, "w:gz") as tar:
-        tar.add(vault, arcname=ARCNAME, filter=_collecting_tar_filter(escaping))
+        added = _add_vault_tree(tar, vault, escaping, unreadable)
         _add_runbook(tar, vault, warnings)
+    if added == 0:
+        raise RuntimeError(
+            "nothing in the vault could be read, so no archive was written"
+            + (f" ({len(unreadable)} entries refused)" if unreadable else ""))
+    if unreadable and warnings is not None:
+        shown = ", ".join(sorted(unreadable)[:5])
+        warnings.append(
+            f"{len(unreadable)} file(s) could not be read by the backup process "
+            f"and are missing from this set ({shown}); everything else is "
+            "backed up. Check the file's permissions, or whether macOS is "
+            "restricting the backup job's access to it")
     if escaping and warnings is not None:
         shown = ", ".join(sorted(escaping)[:5])
         warnings.append(

--- a/core/tests/test_backup_vault.py
+++ b/core/tests/test_backup_vault.py
@@ -4,6 +4,7 @@ All filesystem-only: no network, and every rclone interaction is mocked.
 """
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -470,6 +471,49 @@ def test_links_pointing_outside_the_vault_are_reported_at_backup_time(vault, tmp
     warnings = read_stamp(vault)["warnings"]
     assert any("point outside it" in warning for warning in warnings)
     assert any("linked.md" in warning for warning in warnings)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root can read anything")
+def test_one_unreadable_file_costs_that_file_not_the_backup(vault, tmp_path):
+    """A scheduled run that cannot read one file must still store the rest.
+
+    The real case: an image saved by a sandboxed app carried a per-file access
+    list, the launchd job got "Operation not permitted" on it, and because the
+    whole vault went in through one tar.add() the night stored nothing.
+    """
+    blocked = vault / "05-Areas" / "People" / "blocked.jpeg"
+    blocked.write_bytes(b"\xff\xd8")
+    blocked.chmod(0)
+    dest = tmp_path / "backups"
+    write_config(vault, destination=str(dest))
+    try:
+        assert backup_vault.run_backup(vault) == 0
+    finally:
+        blocked.chmod(0o644)
+
+    stamp = read_stamp(vault)
+    assert stamp["ok"] is True
+    assert any("could not be read" in w and "blocked.jpeg" in w
+               for w in stamp["warnings"])
+    with tarfile.open(dest / f"{backup_vault.PREFIX}{stamp['set']}.tar.gz") as tar:
+        names = tar.getnames()
+    assert f"{backup_vault.ARCNAME}/05-Areas/People/Ada_Lovelace.md" in names
+    assert f"{backup_vault.ARCNAME}/05-Areas/People/blocked.jpeg" not in names
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root can read anything")
+def test_a_vault_with_nothing_readable_fails_loudly(tmp_path):
+    root = tmp_path / "vault"
+    (root / "notes").mkdir(parents=True)
+    (root / "notes" / "a.md").write_text("a")
+    (root / "notes" / "a.md").chmod(0)
+    (root / "notes").chmod(0)
+    try:
+        with pytest.raises(RuntimeError, match="nothing in the vault could be read"):
+            backup_vault.build_artifacts(root, tmp_path, "20260711-020000", [])
+    finally:
+        (root / "notes").chmod(0o755)
+        (root / "notes" / "a.md").chmod(0o644)
 
 
 def test_a_vault_without_stray_links_records_no_warnings(vault, tmp_path):


### PR DESCRIPTION
## What was wrong

A scheduled backup on my vault failed three nights out of forty (14 Aug, 4 Sep, 8 Sep), each time on the same file: an image saved by WhatsApp that macOS had stamped with a per-file access list. The launchd job got `Operation not permitted` on it. On demand the file reads fine.

The defect is in `build_artifacts()`, which I wrote in #461. The vault goes into the archive through a single `tar.add(vault)`, so the first file the process cannot read raises out of the whole walk and the night stores nothing. The function's own docstring argues the opposite case for the git bundle, that a failure there should "degrade rather than abort the run and store nothing at all", and calls the notes archive "the irreplaceable part". That part was the one with no tolerance.

## What this changes

The archive is built one entry at a time. A file the process cannot read is skipped, named in a recorded warning (so the run is not a silent OK, same as the existing link and bundle warnings), and everything else is stored. Only a vault with no readable file at all fails the run, loudly.

The exclusion filter runs per entry exactly as before, excluded directories are not descended, and entries are added in sorted order so two runs of the same vault produce the same archive.

## Tests

Two new cases in `core/tests/test_backup_vault.py`: one unreadable file produces an OK run with a warning naming it and an archive that carries everything else; a vault with nothing readable raises. Both skip under root. The existing 49 cases pass unchanged. All CI gates pass locally against v1.97.13.

## Not changed

Why macOS intermittently refuses the read is not something I can name from three data points; the per-file access list (`com.apple.macl`) on that file is the likely mechanism but this PR does not depend on that being right. It makes the backup honest about a gap instead of losing the night.