### PR TITLE
Fix /zoom-setup: use the official Zoom for Claude connector (the npm package it references doesn't exist)

### DIFF
--- a/.claude/skills/zoom-setup/SKILL.md
+++ b/.claude/skills/zoom-setup/SKILL.md
@@ -1,61 +1,91 @@
 ---
 name: zoom-setup
-description: "Connect Zoom for meeting recordings, scheduling and transcript context. Use when the user says 'connect Zoom', 'pull my Zoom recordings'. Not for Granola-sourced notes; use `granola-setup`. Not for Teams; use `ms-teams-setup`."
+description: "Connect the official Zoom for Claude connector for meeting recordings, transcripts, AI summaries, cloud-recording lists and Zoom Chat/Canvas search. Use when the user says 'connect Zoom', 'pull my Zoom recordings', 'search my Zoom meetings'. Not for Granola-sourced notes; use `granola-setup`. Not for Teams; use `ms-teams-setup`."
 integration:
   id: zoom
   name: Zoom
-  mcp_server: zoom-mcp
+  connector: zoom-for-claude
+  directory_url: https://claude.ai/directory/connectors/zoom-for-claude
   auth: oauth2
   category: meetings
-  sync_direction: bidirectional
+  sync_direction: read
   enhances:
     - skill: meeting-prep
-      capability: "Shows last Zoom with each attendee, surfaces recording summaries"
+      capability: "Surfaces past Zoom recording summaries and transcripts for attendees"
     - skill: process-meetings
-      capability: "Zoom recordings as alternative meeting source alongside Granola"
+      capability: "Zoom cloud recordings and transcripts as a meeting source alongside Granola"
     - skill: week-review
-      capability: "Meeting time stats from Zoom (hours, count, distribution)"
+      capability: "Meeting stats from Zoom cloud recordings (count, recent activity)"
   new_capabilities:
     - name: Recording Search
-      trigger: "During /meeting-prep, search Zoom recordings for past meetings with attendees"
-    - name: Zoom Scheduling
-      trigger: "Schedule Zoom meetings directly from Dex with confirmation"
+      trigger: "During /meeting-prep, search Zoom recordings and transcripts for past meetings with attendees"
+    - name: Canvas Follow-up
+      trigger: "Turn Markdown (e.g. action items) into a follow-up Zoom Canvas, with confirmation"
 ---
 
 # Zoom Setup
 
-Connect your Zoom account to Dex so your meeting prep, reviews, and process-meetings workflows get direct access to Zoom recordings, transcripts, and scheduling.
+Connect the **official Zoom for Claude connector** so your meeting prep, reviews, and
+process-meetings workflows can reach your Zoom recordings, transcripts, AI summaries, and
+Zoom Chat/Canvas.
+
+**Important — how this actually connects.** Zoom for Claude is a **hosted Claude Connector**
+from the [Anthropic Connectors Directory](https://claude.ai/directory/connectors/zoom-for-claude),
+authorized with OAuth in your Claude client. It is **not** a locally-run MCP server and there is
+**no npm package to install**. You enable it once in Claude (exactly like the Notion or Google
+connectors); after that its tools appear in your sessions and Dex uses them. This skill's job is
+to walk you through enabling it, verify it responds, and record that Zoom is available so Dex's
+meeting workflows switch on.
 
 ## What This Enables
 
-Once connected, Dex can:
+Once the connector is enabled, Dex can:
 
 **Read:**
-- List recordings and transcripts from past meetings
-- Search meeting content by keyword or participant
-- Get participant lists and meeting metadata
-- Pull meeting summaries and action items from recordings
+- List your Zoom cloud recordings
+- Retrieve meeting assets: AI summaries, docs, recordings, whiteboards
+- Access recording resources: transcripts, summaries, next steps, playback links
+- Search Zoom meetings, Zoom Chat messages, and Zoom Canvas using natural language
 
-**Write (always with your confirmation):**
-- Schedule Zoom meetings (Dex will always confirm before creating)
-- Add meeting notes or summaries to Zoom
+**Create (always with your confirmation):**
+- Create a follow-up Zoom Canvas from Markdown (e.g. turn extracted action items into a Zoom Doc)
 
 **Skill Enhancements:**
-- **Meeting Prep** (`/meeting-prep`) shows: "Your last Zoom with Sarah: Jan 15. Recording summary available."
-- **Process Meetings** (`/process-meetings`) can process Zoom recordings directly as an alternative to Granola
-- **Week Review** (`/week-review`) includes meeting time stats from Zoom
+- **Meeting Prep** (`/meeting-prep`) surfaces past Zoom recording summaries/transcripts for attendees
+- **Process Meetings** (`/process-meetings`) can use Zoom cloud recordings and transcripts as a meeting source
+- **Week Review** (`/week-review`) can include Zoom cloud-recording activity
 
-**New Capabilities:**
-- **Recording Search:** During `/meeting-prep`, search Zoom recordings for past meetings with attendees and surface summaries
+> **Not supported by this connector:** meeting *scheduling*. The Zoom for Claude connector reads
+> meeting assets and creates Zoom Canvas docs; it does not create or schedule Zoom meetings. Don't
+> promise scheduling.
+
+## Requirements
+
+From Zoom's connector documentation:
+
+- A **licensed** user on a Zoom Workplace **Pro, Pro Plus, Business, Business Plus, Enterprise,
+  Enterprise Plus, or Enterprise Bundle** account
+- A Zoom **account owner or admin** with privileges (connectors may require admin approval)
+- A **Claude account**
+- **AI Companion Smart Recording** and **Meeting Summary** enabled — without both, the connector
+  has limited functionality
+- For video/playback features, meetings must be **recorded to the cloud** using Smart Recording
+
+You can only access a meeting's assets/recordings when you **hosted** that meeting or were
+**granted access** by the host.
 
 ## Privacy
 
-Dex accesses your Zoom account to read recordings and schedule meetings. No recordings are stored locally. Recordings are fetched, summarized, and discarded after the session. Only YOUR account is accessible (scoped to your OAuth login). The OAuth token stays local on your machine and is gitignored.
+This is an official OAuth connector authorized in your Claude client; access is scoped to your
+own Zoom account and to meetings you hosted or were granted. Authorization is handled by
+Claude/Zoom OAuth — there is no local token file for Dex to manage. Dex reads assets on demand
+during a session; it does not store recordings in your vault. Zoom's
+[privacy policy](https://www.zoom.com/en/trust/privacy/privacy-statement/) governs the connector.
 
 ## When to Run
 
 - User types `/zoom-setup`
-- User asks about connecting Zoom
+- User asks about connecting Zoom, or pulling/searching Zoom recordings
 - User wants Zoom recording context in meeting prep
 - During `/integrate-mcp` if Zoom is mentioned
 
@@ -65,299 +95,211 @@ Dex accesses your Zoom account to read recordings and schedule meetings. No reco
 
 ### Step 1: Check if Already Connected
 
-1. Check `System/integrations/config.yaml` for `zoom.enabled: true`
-2. If enabled, try a test query via Zoom MCP (e.g., list recent recordings)
-3. If healthy and responding, skip to **Step 5** (Configure Preferences)
-4. If the tool is not available or errors, continue to Step 2
+1. Check `System/integrations/config.yaml` for `zoom.enabled: true`.
+2. Check whether Zoom connector tools are present in the session (a Zoom connector exposes tools
+   for listing recordings / searching meetings). If they are present and respond, skip to
+   **Step 5 (Save Configuration)** and confirm.
+3. If the tools are not present, continue to Step 2 — the connector still needs enabling in the
+   Claude client.
 
 ### Step 2: Smart Granola Detection
 
-Before explaining the full setup, check if Granola is already connected:
+Check whether Granola is already connected:
 
-1. Read `System/integrations/config.yaml` for a `granola` section
-2. Check if Granola MCP tools are available (try `granola_check_available()`)
+1. Read `System/integrations/config.yaml` for a `granola` section.
+2. Check if Granola MCP tools are available (try `granola_check_available()`).
 
 **If Granola IS connected:**
 
 ```
-You already have Granola connected -- it captures your Zoom meetings automatically.
+You already have Granola connected -- it captures your meeting notes automatically.
 
-Zoom integration would add:
-- Meeting scheduling directly from Dex
-- Access to Zoom cloud recordings (if Granola misses one)
-- Participant metadata (invited vs. attended)
+The Zoom connector would add:
+- Direct access to Zoom cloud recordings, transcripts and AI summaries
+- Search across Zoom meetings, Zoom Chat and Zoom Canvas
+- Creating follow-up Zoom Canvas docs from Markdown
 
-Still want to connect? [Yes / Skip for now]
+Still want to connect Zoom? [Yes / Skip for now]
 ```
 
-If user says "Skip for now", confirm and exit:
-> "No problem. Granola has your meeting capture covered. Run `/zoom-setup` anytime if you want scheduling or recording access later."
+If "Skip for now":
+> "No problem. Granola has your meeting capture covered. Run `/zoom-setup` anytime if you want
+> direct Zoom recording, transcript or Canvas access later."
 
-**If user says "Yes" (Granola connected), continue with adjusted messaging:**
+**If Granola is NOT connected (or user says Yes):** continue.
 
-```
-**Let's connect Zoom to Dex.**
+### Step 3: Enable the Zoom for Claude Connector
 
-Since Granola handles meeting capture, Zoom adds scheduling and direct recording access.
+This is the whole setup — enabling a hosted connector, not installing anything.
 
-**What you'll need:**
-- A Zoom account (Pro or higher for cloud recordings)
-- About 3 minutes for the OAuth flow
-
-**Ready to go?**
-```
-
-**If Granola is NOT connected:**
+Tell the user:
 
 ```
-**Let's connect Zoom to Dex.**
+Zoom for Claude is an official Claude Connector. Here's how to turn it on:
 
-This gives Dex access to your Zoom recordings, transcripts, and scheduling.
+1. Open the Zoom for Claude connector directory page:
+   https://claude.ai/directory/connectors/zoom-for-claude
+2. Click Connect and complete the Zoom OAuth sign-in.
+3. Approve the requested access.
 
-**What you'll need:**
-- A Zoom account (Pro or higher for cloud recordings)
-- About 3 minutes for the OAuth flow
-
-**What Dex will be able to do:**
-- Access your Zoom recordings and transcripts
-- Search meeting content by keyword or participant
-- Schedule Zoom meetings (with your confirmation)
-- Enrich meeting prep with recording summaries
-
-**Ready to go?**
+Requirements: a licensed Zoom Workplace Pro (or higher) seat, account owner/admin privileges,
+and AI Companion Smart Recording + Meeting Summary enabled. Your Zoom admin may need to approve
+the connector first.
 ```
 
-Wait for confirmation.
+**Do not edit `.mcp.json`, run `npx`, or install any package.** There is no `zoom-mcp` package;
+the connector is hosted and enabled through Claude, the same way the Notion and Google connectors
+are.
 
-### Step 3: Add the Zoom MCP Server
+**Session visibility.** A newly enabled connector's tools appear in **new** sessions. If the tools
+are not visible immediately after enabling, tell the user to start a fresh Claude session and run
+`/zoom-setup` again — Dex will then see the Zoom tools. This is expected connector behavior, not a
+failure.
 
-Check the user's MCP configuration. If `zoom-mcp` is not listed:
+### Step 4: Verify the Connection and Check Asset Permissions
 
-1. Explain what we're adding:
+Once the Zoom connector tools are available in the session, run a quick read-only check:
 
-```
-I need to add the Zoom connector to your Dex configuration.
+1. List recent cloud recordings, OR
+2. Search for a recent meeting the user hosted.
 
-This uses an MCP bridge that connects to Zoom's APIs via OAuth.
-Your credentials stay on your machine.
-```
+**Then inspect the per-meeting permission flags the connector returns** — for example
+`has_transcript`, `has_summary`, `has_transcript_permission`, `has_summary_permission`. These
+reveal what *this* account can actually access, which varies by Zoom plan and admin policy.
+Recordings, playback links, attendees and topics are commonly available even when transcript and
+summary access is not. Do not assume transcripts/summaries are available — check.
 
-2. Add to the user's `.mcp.json` (use the `/dex-add-mcp` skill or manual edit):
-
-```json
-{
-  "zoom-mcp": {
-    "command": "npx",
-    "args": ["-y", "zoom-mcp"],
-    "env": {}
-  }
-}
-```
-
-3. Tell the user the MCP server needs to restart for changes to take effect.
-
-### Step 4: Authenticate via OAuth
-
-1. Run the Zoom MCP server -- this starts the OAuth flow
-2. A browser window opens for Zoom sign-in
-3. The user authorizes the requested scopes (recordings, meetings, users)
-4. The token is saved locally
-
-**If OAuth succeeds:**
-```
-Connected! I can see your Zoom account.
-```
-
-**If it fails:**
-```
-The OAuth flow didn't complete. A few things to check:
-
-1. **Did the browser open?** If not, try copying the URL from the terminal output
-2. **Did you approve all permissions?** Dex needs recording and meeting access
-3. **Zoom Pro required?** Cloud recordings require a Pro (or higher) Zoom plan
-4. **Corporate SSO?** Your Zoom admin may restrict OAuth apps
-
-Want to retry?
-```
-
-Retry up to 2 times, then offer to skip and come back later.
-
-### Step 5: Configure Preferences
-
-Once connected, determine feature defaults based on Granola status:
-
-**Feature defaults (with Granola):**
-- `zoom_recordings: false` -- Granola handles transcription; Zoom recordings are a backup
-- `zoom_scheduling: true` -- scheduling is always useful
-
-**Feature defaults (without Granola):**
-- `zoom_recordings: true` -- primary source for meeting recordings
-- `zoom_scheduling: true`
-
-Then ask about scheduling behavior:
+Report honestly what is and isn't available:
 
 ```
-**For scheduling Zoom meetings:**
+**Quick test:**
+- Cloud recordings: found [N]
+- Meeting search: working
+- Transcripts: available / NOT available (no permission on this account)
+- AI summaries: available / NOT available (no permission on this account)
 
-Would you prefer:
-1. **Auto-schedule** -- I'll create the meeting and show you the link
-2. **Ask each time** -- I'll confirm before creating any meetings
-
-(You can change this anytime by re-running /zoom-setup)
+Zoom is connected.
 ```
 
-Save their preference. Map choice 1 to `auto_schedule: true`, choice 2 to `auto_schedule: false`.
+**If transcripts/summaries come back without permission** (`has_transcript_permission: false` /
+`has_summary_permission: false`): this is a Zoom account/admin setting, not a Dex problem. Tell the
+user their account needs AI Companion **Smart Recording** and **Meeting Summary** enabled — often an
+admin action — to unlock transcript and summary access. Until then, recordings, playback links,
+attendees and topics still work. Do not promise transcript- or summary-based features you have just
+observed this account cannot use.
 
-### Step 6: Test the Connection
+**If it responds but returns nothing at all:** likely no cloud recordings the user hosted, or Smart
+Recording is off. Point them at the Requirements rather than reporting a failure.
 
-Run a quick test to confirm everything works:
+**If the tools still aren't visible:** the connector isn't enabled yet, or this session predates
+enabling it. Ask them to enable it at the directory link and start a new session.
 
-1. List recent recordings (last 7 days)
-2. Verify meeting list access
+### Step 5: Save Configuration
 
-Show a brief summary:
-
-```
-**Quick test results:**
-- Recordings: Found [N] recent recordings
-- Meeting list: Working
-
-Everything looks good!
-```
-
-If either fails, troubleshoot before proceeding.
-
-### Step 7: Save Configuration
-
-Write to `System/integrations/config.yaml` -- update the zoom section:
+Write to `System/integrations/config.yaml` — update the `zoom:` section:
 
 ```yaml
 zoom:
   enabled: true
   configured_at: YYYY-MM-DD
-  mcp_server: zoom-mcp
+  connector: zoom-for-claude
+  directory_url: https://claude.ai/directory/connectors/zoom-for-claude
   auth_type: oauth2
-  account: user@example.com
-  granola_coexists: true   # or false -- tracks whether Granola was connected at setup time
+  granola_coexists: true   # or false -- whether Granola was connected at setup time
   features:
-    zoom_recordings: true   # false if Granola connected
-    zoom_scheduling: true
-    auto_schedule: false    # or true based on user preference
+    zoom_recordings: true      # cloud recordings, playback links, attendees, topics
+    zoom_transcripts: false    # set true ONLY if has_transcript_permission was observed in Step 4
+    zoom_summaries: false      # set true ONLY if has_summary_permission was observed in Step 4
+    zoom_canvas: true          # allow creating follow-up Zoom Canvas docs (with confirmation)
 ```
 
-If the file already exists, only update the `zoom:` section. Preserve other integration configs.
+Set `zoom_transcripts` / `zoom_summaries` from the permission flags you actually observed in
+Step 4 — not optimistically. If the file already exists, only update the `zoom:` section and
+preserve other integration configs. Do **not** write an `mcp_server` key or any local token path
+— there is neither.
 
-### Step 8: Confirm with Capability Cascade
-
-**If Granola IS connected:**
-
-```
-**Zoom is connected!**
-
-Here's what just got enhanced:
-
-- **Meeting Prep** (`/meeting-prep`) now includes Zoom context:
-  - Zoom recording links when Granola transcript isn't available
-  - Participant attendance (invited vs. joined)
-  - Scheduling directly from prep
-
-- **Process Meetings** (`/process-meetings`) gains a Zoom fallback:
-  - If Granola missed a meeting, Zoom cloud recording steps in
-  - Same output format (decisions, actions, key points)
-
-- **Week Review** (`/week-review`) now includes Zoom stats:
-  - Total meeting hours
-  - Recording count
-
-Granola remains your primary meeting capture tool. Zoom fills in the gaps.
-
-You can adjust settings anytime by running `/zoom-setup` again.
-```
-
-**If Granola is NOT connected:**
+### Step 6: Confirm with Capability Cascade
 
 ```
 **Zoom is connected!**
 
 Here's what just got enhanced:
 
-- **Meeting Prep** (`/meeting-prep`) now shows Zoom recording context:
-  - Last Zoom meeting with each attendee
-  - Recording summary if available
-  - Participant attendance (invited vs. joined)
+- **Meeting Prep** (`/meeting-prep`) can surface past Zoom recordings, playback links, attendees
+  and topics for the people you're meeting — plus transcripts and summaries *if your account has
+  permission for them*.
+- **Process Meetings** (`/process-meetings`) can pull Zoom cloud recordings as a meeting source;
+  it can use transcripts/summaries only where the account grants them.
+- **Week Review** (`/week-review`) can include Zoom cloud-recording activity.
+- **Follow-ups:** I can turn action items into a follow-up Zoom Canvas doc, with your confirmation.
 
-- **Process Meetings** (`/process-meetings`) can now use Zoom recordings:
-  - Pull transcripts directly from Zoom cloud recordings
-  - Same output format (decisions, actions, key points)
+(The connector reads meeting assets and creates Zoom Canvas docs — it does not schedule meetings.)
+```
 
-- **Week Review** (`/week-review`) now includes Zoom meeting stats:
-  - Total meeting hours from Zoom
-  - Number of recordings this week
-  - Meeting distribution
+**Tailor this to what Step 4 actually found.** If transcript/summary permission was absent, say so
+plainly instead of listing them as live: meeting prep and process-meetings will use recordings,
+playback, attendees and topics until AI Companion Smart Recording + Meeting Summary are enabled on
+the account. Then:
 
-You can adjust settings anytime by running `/zoom-setup` again.
+```
+Adjust anytime by re-running `/zoom-setup`.
 ```
 
 ---
 
 ## Troubleshooting
 
-### OAuth Token Expired
+### Zoom tools don't appear in the session
 
-Zoom OAuth tokens expire periodically. If you see auth errors:
+The connector is enabled per Claude client, and its tools load in **new** sessions.
 
-1. Run `/zoom-setup` to trigger a token refresh
-2. If the refresh token is also expired, you'll need to re-authorize through the browser
-3. This is rare -- usually happens after extended periods or if you revoked access in Zoom settings
+1. Confirm it's enabled at https://claude.ai/directory/connectors/zoom-for-claude
+2. Start a fresh Claude session, then run `/zoom-setup` again
+3. If it's still missing, your Zoom admin may not have approved the connector for your account
 
-### "Zoom MCP not found"
+### Limited functionality / no assets returned
 
-The server might not be in your configuration. Re-run `/zoom-setup` and it will detect and fix this.
+The connector depends on Zoom AI Companion features:
 
-### No Recordings Found
+1. Enable **Smart Recording** and **Meeting Summary** in Zoom
+2. Remember you can only access meetings you **hosted** or were **granted** access to
+3. Video/playback features require **cloud** recordings made with Smart Recording
 
-A few possibilities:
-- **Free plan:** Cloud recordings require Zoom Pro or higher
-- **Recording disabled:** Check your Zoom settings to ensure cloud recording is enabled
-- **Retention policy:** Your Zoom admin may auto-delete recordings after a period
+### No cloud recordings found
 
-### Corporate Zoom Restrictions
+- **Licensing:** requires a licensed Zoom Workplace Pro (or higher) seat
+- **Cloud recording:** local-only recordings aren't accessible; record to the cloud
+- **Retention:** your Zoom admin may auto-delete recordings after a period
 
-Some organizations restrict OAuth access for third-party apps:
+### Corporate Zoom restrictions
 
-1. Check with your IT admin if OAuth is allowed for Zoom
-2. They may need to whitelist the zoom-mcp client ID
-3. Some orgs require admin pre-approval for OAuth apps
+Some organizations require admin approval for connectors:
 
-### Rate Limiting
-
-Zoom APIs have per-second and daily limits. If you see rate errors:
-
-1. Wait 60 seconds and retry
-2. If persistent, you may be hitting an account-level quota
-3. This rarely happens during normal Dex usage
+1. Ask your Zoom admin to approve the Zoom for Claude connector for your account
+2. Owner/admin privileges are listed as a requirement by Zoom
 
 ---
 
 ## Reconfiguration
 
-If the user runs `/zoom-setup` when already configured:
+If the user runs `/zoom-setup` when already connected:
 
-1. Check current status via a test query
-2. Show current config from `System/integrations/config.yaml`
+1. Verify via a quick read-only query (list recordings / search).
+2. Show current config from `System/integrations/config.yaml`.
 3. Offer options:
-   - Change scheduling preferences (auto-schedule vs ask each time)
-   - Toggle recording access (especially if Granola status changed)
-   - Re-authenticate (if token expired)
-   - Disconnect Zoom
+   - Toggle whether Zoom recordings are used as a `/process-meetings` source
+   - Re-verify (if the connector was re-authorized)
+   - Disconnect Zoom in Dex
 
 ### Disconnect Flow
 
-If user wants to disconnect:
+If the user wants Dex to stop using Zoom:
 
 1. Update `System/integrations/config.yaml`:
    ```yaml
    zoom:
      enabled: false
    ```
-2. Confirm: "Zoom is disconnected. Your meeting prep and reviews will no longer include Zoom recording context. Run `/zoom-setup` anytime to reconnect."
+2. Confirm: "Zoom is disconnected in Dex. Meeting prep and reviews will no longer include Zoom
+   recording context. To fully revoke access, remove the Zoom for Claude connector in your Claude
+   connector settings. Run `/zoom-setup` anytime to reconnect."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Dex will be documented in this file.
 
 ---
 
+## [1.97.16] — (2026-09-10)
+
+**Connecting Zoom actually works now.** Before, turning Zoom on failed for everyone: setup told Dex to install a piece of software that was never published, so it could never finish.
+
+**What this fixes for you:**
+
+* **Zoom connects the official way — a one-time sign-in, nothing to install.** Dex now sends you to Zoom's own "Zoom for Claude" connection and you approve it once in your browser, the same simple sign-in you already use for Notion. The old path pointed at software that doesn't exist, so it always dead-ended.
+* **Dex stopped claiming it can schedule Zoom meetings.** The Zoom connection can't do that, so promising it was misleading. What it genuinely does: bring your recordings, transcripts, meeting summaries, and Zoom Chat and Canvas notes into your meeting prep and reviews.
+* **You'll know what you need upfront.** Setup now names the requirements in plain words — a licensed Zoom plan, and Zoom's AI recording and summary features switched on — instead of failing halfway with no explanation.
+
+Reported by @shaunwallace while setting up Dex.
+
 ## [1.97.15] — (2026-09-09)
 
 ## [1.97.14] — (2026-09-09)


### PR DESCRIPTION
## Problem

`/zoom-setup` can't complete. It tells users to register an MCP server backed by an npm package called `zoom-mcp`:

```json
{ "zoom-mcp": { "command": "npx", "args": ["-y", "zoom-mcp"], "env": {} } }
```

That package is **not published** — `npm view zoom-mcp` returns 404 — so setup dead-ends for everyone. The skill also advertises capabilities the real integration doesn't have (most visibly, scheduling Zoom meetings).

## Root cause

"Zoom for Claude" is a **hosted Claude Connector** in the Anthropic Connectors Directory, authorized via OAuth in the Claude client (the same model as the Notion/Google connectors). It is **not** a locally-run MCP server, and there is no npm package to install.

## Fix

Rewrite `.claude/skills/zoom-setup/SKILL.md` to:

- **Enable the official connector** at https://claude.ai/directory/connectors/zoom-for-claude (hosted OAuth). No `.mcp.json` edits, no `npx`.
- **Correct the capabilities** to the connector's documented set: list cloud recordings; retrieve AI summaries/docs/recordings/whiteboards; access transcripts, summaries, next steps and playback links; search Zoom meetings, Chat and Canvas; create follow-up Zoom Canvas from Markdown. **Removed meeting scheduling** — the connector does not schedule meetings.
- **Add documented requirements**: licensed Zoom Workplace Pro+ seat, account owner/admin, AI Companion Smart Recording + Meeting Summary enabled; cloud recording for video features; access limited to meetings you hosted or were granted.
- **Check asset permissions on verify.** Step 4 now inspects per-meeting `has_transcript_permission` / `has_summary_permission` flags and reports honestly which asset types the account can use, rather than assuming transcripts/summaries are available. (Tested against a real account where recordings were reachable but transcript/summary permission was off — the skill surfaces that instead of over-promising.)
- **Fix privacy + frontmatter**: `connector: zoom-for-claude` + `directory_url`; drop `mcp_server: zoom-mcp`; `sync_direction: read`; note there is no local token.
- **Rewrite troubleshooting** for connector reality (tools load in new sessions; Smart Recording/Meeting Summary dependency; admin approval) and drop obsolete `zoom-mcp`/token-refresh guidance.

## Validation

- `npm view zoom-mcp version` → 404 (confirms the referenced package is missing).
- Frontmatter parses (PyYAML); no `mcp_server` key; no `npx`/package-install references remain (only a "do not install" note).
- The integration concierge still surfaces Zoom (`route: skill`, `setup: /zoom-setup`).
- End-to-end: enabling the official connector and running the rewritten skill listed cloud recordings and searched meetings successfully.

## Notes for maintainer

- Changelog version/date (`1.97.16` / 2026-09-10) is a placeholder — please adjust to your release cadence at merge.
- Source of truth: the official Zoom for Claude connector documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
